### PR TITLE
Generate Makefile with dynamic AMDGPU_TARGETS using rocminfo

### DIFF
--- a/stack.py
+++ b/stack.py
@@ -18,11 +18,8 @@ PLUGIN_NAMESPACE_VERSION = "7"
 
 
 MAKE_TEMPLATE = r"""
-# gfx targets for which XLA and jax custom call kernels are built for
-AMDGPU_TARGETS ?= "gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
-
 # customize to a single arch for local dev builds to reduce compile time
-#AMDGPU_TARGETS ?= "gfx908"
+#AMDGPU_TARGETS ?= "$(shell rocminfo | grep -o -m 1 'gfx.*')"
 
 .PHONY: test clean install dist
 

--- a/stack.py
+++ b/stack.py
@@ -19,7 +19,7 @@ PLUGIN_NAMESPACE_VERSION = "7"
 
 MAKE_TEMPLATE = r"""
 # customize to a single arch for local dev builds to reduce compile time
-#AMDGPU_TARGETS ?= "$(shell rocminfo | grep -o -m 1 'gfx.*')"
+AMDGPU_TARGETS ?= "$(shell rocminfo | grep -o -m 1 'gfx.*')"
 
 .PHONY: test clean install dist
 

--- a/stack.py
+++ b/stack.py
@@ -18,6 +18,9 @@ PLUGIN_NAMESPACE_VERSION = "7"
 
 
 MAKE_TEMPLATE = r"""
+# gfx targets for which XLA and jax custom call kernels are built for
+# AMDGPU_TARGETS ?= "gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
+
 # customize to a single arch for local dev builds to reduce compile time
 AMDGPU_TARGETS ?= "$(shell rocminfo | grep -o -m 1 'gfx.*')"
 


### PR DESCRIPTION
- Updated Makefile template to set AMDGPU_TARGETS using: "$(shell rocminfo | grep -o -m 1 'gfx.*')"
- This defers GPU architecture detection to make-time, ensuring compatibility with the local environment.
- Simplifies development by avoiding hardcoded arch lists.
- Still allows overrides via command-line: make `AMDGPU_TARGETS=gfxXYZ`