### PR TITLE
Update Ub24 dockerfile for externally managed python issue

### DIFF
--- a/docker/Dockerfile.jax-ubu24
+++ b/docker/Dockerfile.jax-ubu24
@@ -1,7 +1,9 @@
 FROM ubuntu:24.04
 
+# Install python3 packages and solution for breaking system package 
 RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && apt-get install -y python3 python-is-python3 python3-pip
+    apt-get update && apt-get install -y python3 python-is-python3 python3-pip && \
+    mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MANAGED.old
 
 # Install bzip2 and sqlite3 packages
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
To fix, https://ontrack-internal.amd.com/browse/SWDEV-541284 
Instead of put extra steps in DLM or even Jax dockerfile, easy way to keep one line as kept in this PR to have docker ready with it.

With this PR, we don't need to do "--break-system-packages" everywhere or in future.

