### PR TITLE
Tell the docker build script to tag builds as 'nightly'

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,6 @@ jobs:
         include:
           - rocm-version: "6.4.1"
             runner-label: "mi-250"
-            extra-cr-tag: "nightly"
           - rocm-version: "7.0.0"
             rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
             rocm-build-num: "16322"
@@ -49,6 +48,7 @@ jobs:
       rocm-build-job: ${{ matrix.rocm-build-job }}
       rocm-build-num: ${{ matrix.rocm-build-num }}
       runner-label: ${{ matrix.runner-label }}
+      extra-cr-tag: "nightly"
   run-python-unit-tests:
     needs: call-build-docker
     runs-on: mi-250


### PR DESCRIPTION
Docker images weren't getting tagged with the `nightly` tag. We were just creating the `extra-cr-tag` variable in the matrix. We need to actually pass it into the re-usable workflow.