### PR TITLE
Use test scripts from the rocm/rocm-jax repo rather than rocm/jax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,5 +76,5 @@ jobs:
         run: |
           python3 build/ci_build test \
             "ghcr.io/rocm/jax-ubu22.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
-            --test-cmd "pytest tests/core_test.py"
+            --test-cmd "pytest jax/tests/core_test.py"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,4 +85,4 @@ jobs:
         run: |
           python3 build/ci_build test \
             "ghcr.io/rocm/jax-ubu${UBUNTU_VERSION}.rocm${ROCM_VERSION//.}:${GITHUB_SHA}" \
-            --test-cmd "python build/rocm/run_single_gpu.py -c"
+            --test-cmd "python jax_rocm_plugin/build/rocm/run_single_gpu.py -c"

--- a/build/ci_build
+++ b/build/ci_build
@@ -145,7 +145,7 @@ def test(image_name, test_cmd=None):
     """Run unit tests like CI would inside a JAX image."""
 
     if not test_cmd:
-        test_cmd = "./build/rocm/run_single_gpu.py -c && ./build/rocm/run_multi_gpu.sh"
+        test_cmd = "./jax_rocm_plugin/build/rocm/run_single_gpu.py -c && ./jax_rocm_plugin/build/rocm/run_multi_gpu.sh"
 
     gpu_args = [
         "--device=/dev/kfd",
@@ -172,13 +172,13 @@ def test(image_name, test_cmd=None):
     # JAX and jaxlib are already installed from wheels
     mounts = [
         "-v",
-        os.path.abspath("./jax") + ":/jax",
+        os.path.abspath(".") + ":/rocm-jax",
     ]
 
     cmd.extend(mounts)
     cmd.extend(gpu_args)
 
-    container_cmd = "cd /jax && %s" % test_cmd
+    container_cmd = "cd /rocm-jax && %s" % test_cmd
 
     cmd.append(image_name)
     cmd.extend(


### PR DESCRIPTION
The less code that we have to maintain in rocm/jax, the easier it's going to be to manage code changes. It requires less porting over, and it's easier to devs to understand what they're getting when they run code locally or when CI runs cfode. Right now rocm/rocm-jax is only used for running unit tests, and we have been maintaining the `run_single/multi_gpu.py` scripts in there.

This change modifies the CI workflows and the ci_build script so that we use the versions of `run_single/multi_gpu.py` local to the rocm/rocm-jax repo rather than the version from rocm/jax. This allows us to maintain those scripts here rather than in rocm/jax.