### PR TITLE
Improve stack.py develop options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 `rocm-jax` contains sources for the ROCm plugin for JAX, as well as Dockerfiles used to build AMD's `rocm/jax` images.
 
-
 # Nightly Builds
 
 We build rocm-jax nightly with [a Github Actions workflow](https://github.com/ROCm/rocm-jax/actions/workflows/nightly.yml).


### PR DESCRIPTION
It's helpful for XLA developers to be able to keep their local XLA in a directory other than this repository. To get the JAX development build to work with a different XLA path, this would normally require editing the Makefile. This process is a little cumbersome, and it's easier to set this through an option on the `stack.py` file. This change adds that option. This also adds an argument for building the wheels with a local copy of JAX, similar to the new XLA option, and some make targets for building jaxlib.