### PR TITLE
fix wheel module not found error

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -265,7 +265,7 @@ def fix_wheel(path, jax_path):
         # NOTE(mrodden): auditwheel 6.0 added lddtree module, but 6.3.0 changed
         # the fuction to ldd and also changed its behavior
         # constrain range to 6.0 to 6.2.x
-        cmd = ["pip", "install", "auditwheel>=6,<6.3"]
+        cmd = ["pip", "install", "auditwheel>=6,<6.3", "wheel"]
         subprocess.run(cmd, check=True, env=env)
 
         fixwheel_path = os.path.join(jax_path, "build/rocm/tools/fixwheel.py")


### PR DESCRIPTION
## Motivation

We've been getting `Module not found: wheel` errors when trying to run the `fixwheel.py` script during the nightly build. It's strange that this failed on a weekend, and we're not sure why the `wheel` module isn't getting installed during the build anymore. Likely, we were never installing it anywhere explicitly, and it was a dependency of another module, and the other module no longer requires `wheel`. Or possibly. Either way, making the install explicit right before running `fixwheel.py` fixes the problem.

## Technical Details
Adding this to the `build_wheels.py` fixes `Module not found: wheel` errors
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Tested in http://rocm-ci.amd.com/job/mainline-framework-jax-ub22.04-py3.10/909/
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
