### PR TITLE
Remove verbose logging from auditwheel

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/fixwheel.py
+++ b/jax_rocm_plugin/build/rocm/tools/fixwheel.py
@@ -87,7 +87,7 @@ def fix_wheel(path):
     exclude = list(ext_libs.keys())
 
     # call auditwheel repair with excludes
-    cmd = ["auditwheel", "-v", "repair", "--plat", plat, "--only-plat"]
+    cmd = ["auditwheel", "repair", "--plat", plat, "--only-plat"]
 
     for ex in exclude:
         cmd.append("--exclude")


### PR DESCRIPTION
We don't need `auditwheel` to log as much as it does. It's taking up almost half of the log and is mostly output that we thought would be useful for debugging problems with the wheels but hasn't in fact been that useful.