### PR TITLE
Add pip install to Ubuntu 22 docker build

### DIFF
--- a/docker/Dockerfile.jax-ubu22
+++ b/docker/Dockerfile.jax-ubu22
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && apt-get install -y python3 python-is-python3
+    apt-get update && apt-get install -y python3 python-is-python3 python3-pip
 
 # Install bzip2 and sqlite3 packages
 RUN apt-get update && apt-get install -y \
@@ -25,18 +25,17 @@ RUN --mount=type=bind,source=jax_rocm_plugin/build/rocm/tools/get_rocm.py,target
     --mount=type=bind,from=therock,target=/tmp/therock/ \
     python3 get_rocm.py --rocm-version=$ROCM_VERSION --job-name=$ROCM_BUILD_JOB --build-num=$ROCM_BUILD_NUM --therock-path=$THEROCK_PATH
 ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
-ENV ln -s "/opt/rocm-${ROCM_RELEASE}/lib/librocblas.so.5" "/opt/rocm-${ROCM_RELEASE}/lib/librocblas.so.4"
-ENV LD_LIBRARY_PATH="/opt/rocm-${ROCM_VERSION}/lib:$LD_LIBRARY_PATH"
+ENV LD_LIBRARY_PATH="/opt/rocm-${ROCM_VERSION}/lib:${LD_LIBRARY_PATH}"
 ENV LLVM_PATH="/opt/rocm-${ROCM_VERSION}/llvm"
 
 # Set up paths
-ENV HCC_HOME=$ROCM_PATH/hcc
-ENV HIP_PATH=$ROCM_PATH/
-ENV OPENCL_ROOT=$ROCM_PATH/opencl
+ENV HCC_HOME="$ROCM_PATH/hcc"
+ENV HIP_PATH="$ROCM_PATH/"
+ENV OPENCL_ROOT="$ROCM_PATH/opencl"
 ENV PATH="$HCC_HOME/bin:$HIP_PATH/bin:${PATH}"
 ENV PATH="$ROCM_PATH/bin:${PATH}"
 ENV PATH="$OPENCL_ROOT/bin:${PATH}"
-ENV PATH="/root/bin:/root/.local/bin:$PATH"
+ENV PATH="/root/bin:/root/.local/bin:${PATH}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     pip3 install --upgrade --force-reinstall setuptools pip && \


### PR DESCRIPTION
Installs pip3 when we install Python. I'm not sure how this docker file was able to build before.

Does some other minor fixes to make sure that we don't get path problems when we have weirdly named directories.