### PR TITLE
Fix build number for ROCm 7.0.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
             runner-label: "mi-250"
           - rocm-version: "7.0.0"
             rocm-build-job: "compute-rocm-rel-7.0"
-            rocm-build-num: "42"
+            rocm-build-num: "40"
             runner-label: "internal"
     uses: ./.github/workflows/build-wheels.yml
     with:
@@ -40,7 +40,7 @@ jobs:
             runner-label: "mi-250"
           - rocm-version: "7.0.0"
             rocm-build-job: "compute-rocm-rel-7.0"
-            rocm-build-num: "42"
+            rocm-build-num: "40"
             runner-label: "internal"
     uses: ./.github/workflows/build-docker.yml
     with:


### PR DESCRIPTION
The last build number used for ROCm 7.0.0 is 40, not 42. It is used in nightly, and updated for correct results.