### PR TITLE
Switch to official version for ROCm 7.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,9 +19,7 @@ jobs:
           - rocm-version: "6.4.1"
             runner-label: "mi-250"
           - rocm-version: "7.0.0"
-            rocm-build-job: "compute-rocm-rel-7.0"
-            rocm-build-num: "40"
-            runner-label: "internal"
+            runner-label: "mi-250"
     uses: ./.github/workflows/build-wheels.yml
     with:
       python-versions: "3.10,3.12"


### PR DESCRIPTION
Since the official release for ROCm 7.0.0 is out, this PR switches the nightly build configuration to use the official version instead of the internal build number.