### PR TITLE
fix to work with released ROCm 7.0.0 when using --rocm-version=7.0.0

### DIFF
--- a/jax_rocm_plugin/build/rocm/tools/get_rocm.py
+++ b/jax_rocm_plugin/build/rocm/tools/get_rocm.py
@@ -413,16 +413,22 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
         )
 
     with open("/etc/yum.repos.d/amdgpu.repo", "w") as afd:
+        if rocm_version_str.startswith("7"):
+            repodir = "graphics"
+            rhel_minor = 10
+        else:
+            repodir = "amdgpu"
+            rhel_minor = 8
         afd.write(
             """
 [amdgpu]
 name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/%s/rhel/8.8/main/x86_64/
+baseurl=https://repo.radeon.com/%s/%s/rhel/8.{rhel}/main/x86_64/
 enabled=1
 gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 """
-            % rocm_version_str
+            % (repodir, rocm_version_str, rhel_minor)
         )
 
 


### PR DESCRIPTION
## Motivation

The URL for the repo containing libdrm-amdgpu and friends has changed with ROCm 7. This commit adds support for the new URL scheme.

## Technical Details

Not a technical commit.

## Test Plan & Result

Successfully ran ci_build for both the dist_wheels and build_dockers; resulting image can run jax.
