### PR TITLE
CI: Prevent intermittent checkout failures on NFS-based runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,15 @@ jobs:
             /bin/bash -c "shopt -s dotglob; chown -R $UID /rocm-jax/* || true"
       - name: Checkout plugin repo
         uses: actions/checkout@v4
+        with:
+          clean: false
       - name: Checkout JAX repo
         uses: actions/checkout@v4
         with:
           # TODO: Load the ref from a file that sets the min and max JAX version
           # TODO: Change the repo and ref once we figure out how exactly we're going to
           #       manage tests
+          clean: false
           repository: rocm/jax
           ref: rocm-jaxlib-v0.7.1
           path: jax


### PR DESCRIPTION
### Short Description
This PR addresses an intermittent CI failure that occurs on our self-hosted runners.

### Motivation
The workflow has been failing sporadically with an E`BUSY: resource busy or locked` error during the `actions/checkout` step. This happens because our runners use an NFS mount for their workspace.
If a previous workflow run terminates abnormally (e.g., is cancelled or crashes), it can leave behind a stale `.nfs` lock file. When the next job starts on that same runner, the default `clean: true` behavior of `actions/checkout` attempts to delete all files and fails when it encounters this locked file.

### Solution
This change resolves the issue by setting `clean: false` on the `actions/checkout@v4` steps.
This prevents the action from trying to delete the workspace contents, thereby avoiding any conflict with stale NFS lock files. The checkout process will still overwrite all files in the workspace, ensuring a fresh source tree for the job without triggering the error.