### PR TITLE
Fix nightly and use ROCm 7.0.0 for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   call-build-wheels:
     strategy:
       matrix:
-        rocm-version: ["6.4.1"]
+        rocm-version: ["7.0.0"]
     uses: ./.github/workflows/build-wheels.yml
     with:
       # TODO: Add back Python 3.13 when we're ready to move to a more recent version of XLA. 3.13
@@ -30,7 +30,7 @@ jobs:
     needs: call-build-wheels
     strategy:
       matrix:
-        rocm-version: ["6.4.1"]
+        rocm-version: ["7.0.0"]
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
@@ -39,7 +39,7 @@ jobs:
     runs-on: mi-250
     strategy:
       matrix:
-        rocm-version: ["6.4.1"]
+        rocm-version: ["7.0.0"]
     steps:
       - name: Change owners for cleanup
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         rocm-version: ["7.0.0", "7.1.0"]
         include:
-          - rocm-version: "7.1.0"
-            runner-label: "mi-250"
           - rocm-version: "7.0.0"
-            rocm-build-job: "compute-rocm-rel-7.0"
-            rocm-build-num: "40"
+            runner-label: "mi-250"
+          - rocm-version: "7.1.0"
+            rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
+            rocm-build-num: "16674"
             runner-label: "internal"
     uses: ./.github/workflows/build-wheels.yml
     with:
@@ -36,11 +36,11 @@ jobs:
       matrix:
         rocm-version: ["7.0.0", "7.1.0"]
         include:
-          - rocm-version: "7.1.0"
-            runner-label: "mi-250"
           - rocm-version: "7.0.0"
-            rocm-build-job: "compute-rocm-rel-7.0"
-            rocm-build-num: "40"
+            runner-label: "mi-250"
+          - rocm-version: "7.1.0"
+            rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
+            rocm-build-num: "16674"
             runner-label: "internal"
     uses: ./.github/workflows/build-docker.yml
     with:


### PR DESCRIPTION
Fix nightly ROCm installation and move CI builds to ROCm 7.0.0.