### PR TITLE
Update XLA commit hash to the recent commit on 9/25/2025

### DIFF
--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -18,11 +18,11 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 # To update XLA to a new revision,
 # a) update XLA_COMMIT to the new git commit hash
 # b) get the sha256 hash of the commit by running:
-#    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
+#    curl -L https://github.com/ROCm/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "3b077fcf723b3dda24868f603419d0c914f478e0"
-XLA_SHA256 = "3aa872e1a47ba40dab88f0230db55eb703e54df58ea7b7a41a744091b546ea03"
+XLA_COMMIT = "ff74b5fda7dec651c9ed3d7a2bab4365ca25d61f"
+XLA_SHA256 = "414d0037cf4a36c0179b1e4d87517875110afd689eff3e8a8e100b202c354cbd"
 
 def repo():
     tf_http_archive(


### PR DESCRIPTION
## Motivation
This PR updates the XLA commit hash to ff74b5fda7dec651c9ed3d7a2bab4365ca25d61f, which was merged on 9/25/2025. The description for this commit hash is: **update to remove previously hard-coded rocprofiler-sdk path** (https://github.com/ROCm/xla/pull/369)

The commit hash was tested and recent wheels are built using this.

The 0.6.0 release will use this commit hash. After this, since the wheels will be uploaded, the XLA commit hash will remain same for 0.6.0.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
