### PR TITLE
fix to work with released ROCm 7.0.1 when using --rocm-version=7.0.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # release branch for rocm7.0 is semi-locked
 # fixes should go first to master and be backported as necessary
-* @mrodden
+* @mrodden @charleshofer @JehandadKhan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# release branch for rocm7.0 is semi-locked
+# fixes should go first to master and be backported as necessary
+* @mrodden

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
     steps:
       - name: Change owners for cleanup
         run: |
-          docker run --rm -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
+          docker run --rm -v "./:/rocm-jax" ubuntu \
+            /bin/bash -c "shopt -s dotglob; chown -R $UID /rocm-jax/* || true"
       - name: Checkout plugin repo
         uses: actions/checkout@v4
       - name: Checkout JAX repo

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,8 @@ jobs:
     steps:
       - name: Change owners for cleanup
         run: |
-          docker run --rm -v "./:/rocm-jax" ubuntu /bin/bash -c "chown -R $UID /rocm-jax/* || true"
+          docker run --rm -v "./:/rocm-jax" ubuntu \
+            /bin/bash -c "shopt -s dotglob; chown -R $UID /rocm-jax/* || true"
       - name: Checkout plugin repo
         uses: actions/checkout@v4
       - name: Checkout JAX repo

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["6.4.1", "7.0"]
+        rocm-version: ["6.4.1", "7.0.0"]
         include:
           - rocm-version: "6.4.1"
             runner-label: "mi-250"
-          - rocm-version: "7.0"
-            rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
-            rocm-build-num: "16322"
+          - rocm-version: "7.0.0"
+            rocm-build-job: "compute-rocm-rel-7.0"
+            rocm-build-num: "40"
             runner-label: "internal"
     uses: ./.github/workflows/build-wheels.yml
     with:
@@ -34,14 +34,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["6.4.1", "7.0"]
+        rocm-version: ["6.4.1", "7.0.0"]
         include:
           - rocm-version: "6.4.1"
             runner-label: "mi-250"
             extra-cr-tag: "nightly"
-          - rocm-version: "7.0"
-            rocm-build-job: "compute-rocm-dkms-no-npi-hipclang"
-            rocm-build-num: "16322"
+          - rocm-version: "7.0.0"
+            rocm-build-job: "compute-rocm-rel-7.0"
+            rocm-build-num: "40"
             runner-label: "internal"
             extra-cr-tag: "nightly"
     uses: ./.github/workflows/build-docker.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rocm-version: ["6.4.1", "7.0"]
+        rocm-version: ["6.4.1", "7.0.0"]
         ubuntu-version: ["22", "24"]
     steps:
       - name: Change owners for cleanup

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# vscode local settings
+/.vscode
+
+# script produced by tools/docker_dev_setup.sh
+/llvm.sh

--- a/jax_rocm_plugin/.bazelrc
+++ b/jax_rocm_plugin/.bazelrc
@@ -387,7 +387,7 @@ build:rbe_cross_compile_darwin_x86_64 --config=rbe_cross_compile_base
 #############################################################################
 
 build:debug_symbols --strip=never --per_file_copt="xla/pjrt|xla/python@-g3"
-build:debug --config debug_symbols -c fastbuild
+build:debug --config=debug_symbols -c fastbuild
 
 # Load `.jax_configure.bazelrc` file written by build.py
 try-import %workspace%/.jax_configure.bazelrc

--- a/jax_rocm_plugin/build/rocm/tools/build_wheels.py
+++ b/jax_rocm_plugin/build/rocm/tools/build_wheels.py
@@ -265,7 +265,7 @@ def fix_wheel(path, jax_path):
         # NOTE(mrodden): auditwheel 6.0 added lddtree module, but 6.3.0 changed
         # the fuction to ldd and also changed its behavior
         # constrain range to 6.0 to 6.2.x
-        cmd = ["pip", "install", "auditwheel>=6,<6.3"]
+        cmd = ["pip", "install", "auditwheel>=6,<6.3", "wheel"]
         subprocess.run(cmd, check=True, env=env)
 
         fixwheel_path = os.path.join(jax_path, "build/rocm/tools/fixwheel.py")

--- a/jax_rocm_plugin/build/rocm/tools/get_rocm.py
+++ b/jax_rocm_plugin/build/rocm/tools/get_rocm.py
@@ -320,16 +320,22 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
         )
 
     with open("/etc/yum.repos.d/amdgpu.repo", "w") as afd:
+        if rocm_version_str.startswith("7"):
+            repodir = "graphics"
+            rhel_minor = 10
+        else:
+            repodir = "amdgpu"
+            rhel_minor = 8
         afd.write(
             """
 [amdgpu]
 name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/%s/rhel/8.8/main/x86_64/
+baseurl=https://repo.radeon.com/%s/%s/rhel/8.%d/main/x86_64/
 enabled=1
 gpgcheck=1
 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
 """
-            % rocm_version_str
+            % (repodir, rocm_version_str, rhel_minor)
         )
 
 

--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -21,8 +21,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "44f7d8796da5b42f3b9483fd6750edaf8018f538"
-XLA_SHA256 = "48f5b405824d88d440c990608e107c7ed05c1322cfe5a4aca0530fc0a15d6bad"
+XLA_COMMIT = "50860e943202307ad17ef3bc513289dfbd1b92bc"
+XLA_SHA256 = "0d8a10fc1674a347542f280c724167f1fbe7f53cc8d59f49ee5d196166c8ee0c"
 
 def repo():
     tf_http_archive(

--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -21,8 +21,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "501532fb9bd87579fecd899ca2712ac8227a17ba"
-XLA_SHA256 = "d7736949f80c5d6bc34d5c6155b4b747a4f5348b892b878b8447c0546059a595"
+XLA_COMMIT = "44f7d8796da5b42f3b9483fd6750edaf8018f538"
+XLA_SHA256 = "48f5b405824d88d440c990608e107c7ed05c1322cfe5a4aca0530fc0a15d6bad"
 
 def repo():
     tf_http_archive(

--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -21,8 +21,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "50860e943202307ad17ef3bc513289dfbd1b92bc"
-XLA_SHA256 = "0d8a10fc1674a347542f280c724167f1fbe7f53cc8d59f49ee5d196166c8ee0c"
+XLA_COMMIT = "efa9d45075493db1fe9f02ab80cef71ed4064ff8"
+XLA_SHA256 = "33a6e16720b60b817f294deb35d8f688875c42ffbc286b8840f1f1a270d60b5f"
 
 def repo():
     tf_http_archive(

--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -21,8 +21,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "efa9d45075493db1fe9f02ab80cef71ed4064ff8"
-XLA_SHA256 = "33a6e16720b60b817f294deb35d8f688875c42ffbc286b8840f1f1a270d60b5f"
+XLA_COMMIT = "3b077fcf723b3dda24868f603419d0c914f478e0"
+XLA_SHA256 = "3aa872e1a47ba40dab88f0230db55eb703e54df58ea7b7a41a744091b546ea03"
 
 def repo():
     tf_http_archive(


### PR DESCRIPTION
## Motivation

The URL for the repo containing libdrm-amdgpu and friends has changed with ROCm 7. This commit adds support for the new URL scheme.

Note that ROCm 7.0 can not be referred to as 7.0.0, but must be referred to as 7.0 - this is due to the repo structure.

## Technical Details

Not a technical commit.

## Test Plan & Result

Successfully ran ci_build for both the dist_wheels and build_dockers; resulting image can run jax.
