### PR TITLE
Handle tests/ prefix in pytest nodeid parsing

### DIFF
--- a/ci/pytest_skips.ini
+++ b/ci/pytest_skips.ini
@@ -9,7 +9,7 @@ addopts =
           --deselect jax/tests/image_test.py::ImageTest::testResizeGradients
 # LAX
           --deselect jax/tests/lax_numpy_reducers_test.py::JaxNumpyReducerTests::testCov
-          --deselect jax/tests/tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_cg_as_solve
+          --deselect jax/tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_cg_as_solve
 # Linear Algebra
           --deselect jax/tests/linalg_test.py::ScipyLinalgTest::testLuGrad
           --deselect jax/tests/linalg_test.py::ScipyLinalgTest::testExpm

--- a/jax_rocm_plugin/build/rocm/run_single_gpu.py
+++ b/jax_rocm_plugin/build/rocm/run_single_gpu.py
@@ -120,7 +120,8 @@ def parse_test_log(log_file):
             if "nodeid" in report:
                 module = report["nodeid"].split("::")[0]
                 if module and ".py" in module:
-                    test_files.add(os.path.abspath("./jax/tests/" + module))
+                    prefix = "" if module.startswith("tests/") else "tests/"
+                    test_files.add(os.path.abspath("./jax/" + prefix + module))
     return test_files
 
 


### PR DESCRIPTION
Pytest can return different nodeid formats, and with skip.ini file it is observed that:

- with `-c pytest_skips.ini`: tests/<test_name>.py
- without skip.ini: <test_name>.py

This PR updates parse_test_log() to add "tests/" prefix only when missing.