### PR TITLE
Adding rpath for /opt/rocm/libs since librccl.so etc is not found

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,3 @@
 [MESSAGES CONTROL]
 
-disable = consider-using-f-string
+disable = consider-using-f-string,duplicate-code

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -17,6 +17,12 @@
 
 # Most users should not run this script directly; use build.py instead.
 
+# pylint: disable=R0801
+
+"""
+Script to build a JAX ROCm kernel plugin wheel. Intended for use via Bazel.
+"""
+
 import argparse
 import functools
 import os
@@ -25,9 +31,11 @@ import stat
 import subprocess
 import tempfile
 
+# pylint: disable=import-error
 from bazel_tools.tools.python.runfiles import runfiles
 from jaxlib_ext.tools import build_utils
 
+# pylint: enable=R0801
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--output_path",
@@ -58,120 +66,127 @@ parser.add_argument(
 parser.add_argument(
     "--enable-cuda",
     default=False,
-    help="Should we build with CUDA enabled? Requires CUDA and CuDNN.")
+    help="Should we build with CUDA enabled? Requires CUDA and CuDNN.",
+)
 parser.add_argument(
-    "--enable-rocm",
-    default=False,
-    help="Should we build with ROCM enabled?")
+    "--enable-rocm", default=False, help="Should we build with ROCM enabled?"
+)
 args = parser.parse_args()
 
 r = runfiles.Create()
-pyext = "pyd" if build_utils.is_windows() else "so"
+PYEXT = "pyd" if build_utils.is_windows() else "so"
 
 
-def write_setup_cfg(sources_path, cpu):
-  tag = build_utils.platform_tag(cpu)
-  with open(sources_path / "setup.cfg", "w") as f:
-    f.write(f"""[metadata]
+def write_setup_cfg(setup_cfg_path, cpu):
+    """Write setup.cfg with platform tag."""
+    tag = build_utils.platform_tag(cpu)
+    with open(setup_cfg_path / "setup.cfg", "w", encoding="utf-8") as f:
+        f.write(
+            f"""[metadata]
 license_files = LICENSE.txt
 
 [bdist_wheel]
 plat_name={tag}
-""")
+"""
+        )
 
 
-def prepare_wheel_rocm(
-    sources_path: pathlib.Path, *, cpu, rocm_version
-):
-  """Assembles a source tree for the rocm kernel wheel in `sources_path`."""
-  copy_runfiles = functools.partial(build_utils.copy_file, runfiles=r)
+def prepare_wheel_rocm(rocm_sources_path: pathlib.Path, *, cpu, rocm_version):
+    """Assembles a source tree for the rocm kernel wheel in `rocm_sources_path`."""
+    copy_runfiles = functools.partial(build_utils.copy_file, runfiles=r)
 
-  copy_runfiles(
-      "__main__/jax_plugins/rocm/plugin_pyproject.toml",
-      dst_dir=sources_path,
-      dst_filename="pyproject.toml",
-  )
-  copy_runfiles(
-      "__main__/jax_plugins/rocm/plugin_setup.py",
-      dst_dir=sources_path,
-      dst_filename="setup.py",
-  )
-  build_utils.update_setup_with_rocm_version(sources_path, rocm_version)
-  write_setup_cfg(sources_path, cpu)
-
-  plugin_dir = sources_path / f"jax_rocm{rocm_version}_plugin"
-  copy_runfiles(
-      dst_dir=plugin_dir,
-      src_files=[
-          f"jax/jaxlib/rocm/_linalg.{pyext}",
-          f"jax/jaxlib/rocm/_prng.{pyext}",
-          f"jax/jaxlib/rocm/_solver.{pyext}",
-          f"jax/jaxlib/rocm/_sparse.{pyext}",
-          f"jax/jaxlib/rocm/_hybrid.{pyext}",
-          f"jax/jaxlib/rocm/_rnn.{pyext}",
-          f"jax/jaxlib/rocm/_triton.{pyext}",
-          f"jax/jaxlib/rocm/rocm_plugin_extension.{pyext}",
-          "jax/jaxlib/version.py",
-      ],
-  )
-
-  # NOTE(mrodden): this is a hack to change/set rpath values
-  # in the shared objects that are produced by the bazel build
-  # before they get pulled into the wheel build process.
-  # we have to do this change here because setting rpath
-  # using bazel requires the rpath to be valid during the build
-  # which won't be correct until we make changes to
-  # the xla/tsl/jax plugin build
-
-  try:
-    subprocess.check_output(["which", "patchelf"])
-  except subprocess.CalledProcessError as ex:
-    mesg = (
-        "rocm plugin and kernel wheel builds require patchelf. "
-        "please install 'patchelf' and run again"
+    copy_runfiles(
+        "__main__/jax_plugins/rocm/plugin_pyproject.toml",
+        dst_dir=rocm_sources_path,
+        dst_filename="pyproject.toml",
     )
-    raise Exception(mesg) from ex
-
-  files = [
-      f"_linalg.{pyext}",
-      f"_prng.{pyext}",
-      f"_solver.{pyext}",
-      f"_sparse.{pyext}",
-      f"_hybrid.{pyext}",
-      f"_rnn.{pyext}",
-      f"_triton.{pyext}",
-      f"rocm_plugin_extension.{pyext}",
-  ]
-  runpath = '$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib'
-  # patchelf --force-rpath --set-rpath $RUNPATH $so
-  for f in files:
-    so_path = os.path.join(plugin_dir, f)
-    fix_perms = False
-    perms = os.stat(so_path).st_mode
-    if not perms & stat.S_IWUSR:
-        fix_perms = True
-        os.chmod(so_path, perms | stat.S_IWUSR)
-    subprocess.check_call(["patchelf", "--force-rpath", "--set-rpath", runpath, so_path])
-    if fix_perms:
-        os.chmod(so_path, perms)
-
-tmpdir = tempfile.TemporaryDirectory(prefix="jax_rocm_plugin")
-sources_path = tmpdir.name
-try:
-  os.makedirs(args.output_path, exist_ok=True)
-  prepare_wheel_rocm(
-      pathlib.Path(sources_path), cpu=args.cpu, rocm_version=args.platform_version
-  )
-  package_name = f"jax rocm{args.platform_version} plugin"
-  if args.editable:
-    build_utils.build_editable(sources_path, args.output_path, package_name)
-  else:
-    git_hash = build_utils.get_githash(args.jaxlib_git_hash)
-    build_utils.build_wheel(
-        sources_path,
-        args.output_path,
-        package_name,
-        git_hash=git_hash,
+    copy_runfiles(
+        "__main__/jax_plugins/rocm/plugin_setup.py",
+        dst_dir=rocm_sources_path,
+        dst_filename="setup.py",
     )
-finally:
-  tmpdir.cleanup()
+    build_utils.update_setup_with_rocm_version(rocm_sources_path, rocm_version)
+    write_setup_cfg(rocm_sources_path, cpu)
+
+    plugin_dir = rocm_sources_path / f"jax_rocm{rocm_version}_plugin"
+    copy_runfiles(
+        dst_dir=plugin_dir,
+        src_files=[
+            f"jax/jaxlib/rocm/_linalg.{PYEXT}",
+            f"jax/jaxlib/rocm/_prng.{PYEXT}",
+            f"jax/jaxlib/rocm/_solver.{PYEXT}",
+            f"jax/jaxlib/rocm/_sparse.{PYEXT}",
+            f"jax/jaxlib/rocm/_hybrid.{PYEXT}",
+            f"jax/jaxlib/rocm/_rnn.{PYEXT}",
+            f"jax/jaxlib/rocm/_triton.{PYEXT}",
+            f"jax/jaxlib/rocm/rocm_plugin_extension.{PYEXT}",
+            "jax/jaxlib/version.py",
+        ],
+    )
+
+    # NOTE(mrodden): this is a hack to change/set rpath values
+    # in the shared objects that are produced by the bazel build
+    # before they get pulled into the wheel build process.
+    # we have to do this change here because setting rpath
+    # using bazel requires the rpath to be valid during the build
+    # which won't be correct until we make changes to
+    # the xla/tsl/jax plugin build
+
+    try:
+        subprocess.check_output(["which", "patchelf"])
+    except subprocess.CalledProcessError as ex:
+        mesg = (
+            "rocm plugin and kernel wheel builds require patchelf. "
+            "please install 'patchelf' and run again"
+        )
+        raise RuntimeError(mesg) from ex
+
+    files = [
+        f"_linalg.{PYEXT}",
+        f"_prng.{PYEXT}",
+        f"_solver.{PYEXT}",
+        f"_sparse.{PYEXT}",
+        f"_hybrid.{PYEXT}",
+        f"_rnn.{PYEXT}",
+        f"_triton.{PYEXT}",
+        f"rocm_plugin_extension.{PYEXT}",
+    ]
+    runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib"
+    # patchelf --force-rpath --set-rpath $RUNPATH $so
+    for fname in files:
+        so_path = os.path.join(plugin_dir, fname)
+        fix_perms = False
+        perms = os.stat(so_path).st_mode
+        if not perms & stat.S_IWUSR:
+            fix_perms = True
+            os.chmod(so_path, perms | stat.S_IWUSR)
+        subprocess.check_call(
+            ["patchelf", "--force-rpath", "--set-rpath", runpath, so_path]
+        )
+        if fix_perms:
+            os.chmod(so_path, perms)
+
+
+def main():
+    """Main entry point for building the ROCm kernel plugin wheel."""
+    with tempfile.TemporaryDirectory(prefix="jax_rocm_plugin") as tmpdir:
+        sources_path = tmpdir
+        os.makedirs(args.output_path, exist_ok=True)
+        prepare_wheel_rocm(
+            pathlib.Path(sources_path), cpu=args.cpu, rocm_version=args.platform_version
+        )
+        package_name = f"jax rocm{args.platform_version} plugin"
+        if args.editable:
+            build_utils.build_editable(sources_path, args.output_path, package_name)
+        else:
+            git_hash = build_utils.get_githash(args.jaxlib_git_hash)
+            build_utils.build_wheel(
+                sources_path,
+                args.output_path,
+                package_name,
+                git_hash=git_hash,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -16,6 +16,7 @@
 # run via bazel run as part of the jax cuda plugin build process.
 
 # Most users should not run this script directly; use build.py instead.
+# pylint: disable=duplicate-code
 
 """
 Script to build a JAX ROCm kernel plugin wheel. Intended for use via Bazel.

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -17,8 +17,6 @@
 
 # Most users should not run this script directly; use build.py instead.
 
-# pylint: disable=R0801
-
 """
 Script to build a JAX ROCm kernel plugin wheel. Intended for use via Bazel.
 """
@@ -35,7 +33,6 @@ import tempfile
 from bazel_tools.tools.python.runfiles import runfiles
 from jaxlib_ext.tools import build_utils
 
-# pylint: enable=R0801
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--output_path",
@@ -80,8 +77,8 @@ PYEXT = "pyd" if build_utils.is_windows() else "so"
 def write_setup_cfg(setup_cfg_path, cpu):
     """Write setup.cfg with platform tag."""
     tag = build_utils.platform_tag(cpu)
-    with open(setup_cfg_path / "setup.cfg", "w", encoding="utf-8") as f:
-        f.write(
+    with open(setup_cfg_path / "setup.cfg", "w", encoding="utf-8") as cfg_file:
+        cfg_file.write(
             f"""[metadata]
 license_files = LICENSE.txt
 
@@ -160,9 +157,7 @@ def prepare_wheel_rocm(rocm_sources_path: pathlib.Path, *, cpu, rocm_version):
         if not perms & stat.S_IWUSR:
             fix_perms = True
             os.chmod(so_path, perms | stat.S_IWUSR)
-        subprocess.check_call(
-            ["patchelf", "--set-rpath", runpath, so_path]
-        )
+        subprocess.check_call(["patchelf", "--set-rpath", runpath, so_path])
         if fix_perms:
             os.chmod(so_path, perms)
 

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -142,7 +142,7 @@ def prepare_wheel_rocm(
       f"_triton.{pyext}",
       f"rocm_plugin_extension.{pyext}",
   ]
-  runpath = '$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib'
+  runpath = '$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib'
   # patchelf --force-rpath --set-rpath $RUNPATH $so
   for f in files:
     so_path = os.path.join(plugin_dir, f)

--- a/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
+++ b/jax_rocm_plugin/jaxlib_ext/tools/build_gpu_kernels_wheel.py
@@ -152,7 +152,7 @@ def prepare_wheel_rocm(rocm_sources_path: pathlib.Path, *, cpu, rocm_version):
         f"rocm_plugin_extension.{PYEXT}",
     ]
     runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib"
-    # patchelf --force-rpath --set-rpath $RUNPATH $so
+    # patchelf --set-rpath $RUNPATH $so
     for fname in files:
         so_path = os.path.join(plugin_dir, fname)
         fix_perms = False
@@ -161,7 +161,7 @@ def prepare_wheel_rocm(rocm_sources_path: pathlib.Path, *, cpu, rocm_version):
             fix_perms = True
             os.chmod(so_path, perms | stat.S_IWUSR)
         subprocess.check_call(
-            ["patchelf", "--force-rpath", "--set-rpath", runpath, so_path]
+            ["patchelf", "--set-rpath", runpath, so_path]
         )
         if fix_perms:
             os.chmod(so_path, perms)

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -17,8 +17,6 @@
 
 # Most users should not run this script directly; use build.py instead.
 
-# pylint: disable=R0801
-
 """
 Script to build a JAX ROCm plugin wheel. Intended for use via Bazel.
 """
@@ -36,7 +34,6 @@ from bazel_tools.tools.python.runfiles import runfiles
 from pjrt.tools import build_utils
 
 
-# pylint: disable=R0801
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--sources_path",
@@ -74,7 +71,6 @@ parser.add_argument(
     "--enable-rocm", default=False, help="Should we build with ROCM enabled?"
 )
 args = parser.parse_args()
-# pylint: enable=R0801
 
 r = runfiles.Create()
 
@@ -82,8 +78,8 @@ r = runfiles.Create()
 def write_setup_cfg(setup_cfg_path, cpu):
     """Write setup.cfg with platform tag."""
     tag = build_utils.platform_tag(cpu)
-    with open(setup_cfg_path / "setup.cfg", "w", encoding="utf-8") as f:
-        f.write(
+    with open(setup_cfg_path / "setup.cfg", "w", encoding="utf-8") as cfg_file:
+        cfg_file.write(
             f"""[metadata]
 license_files = LICENSE.txt
 
@@ -146,9 +142,7 @@ def prepare_rocm_plugin_wheel(rocm_sources_path: pathlib.Path, *, cpu, rocm_vers
     if not perms & stat.S_IWUSR:
         fix_perms = True
         os.chmod(shared_obj_path, perms | stat.S_IWUSR)
-    subprocess.check_call(
-        ["patchelf", "--set-rpath", runpath, shared_obj_path]
-    )
+    subprocess.check_call(["patchelf", "--set-rpath", runpath, shared_obj_path])
     if fix_perms:
         os.chmod(shared_obj_path, perms)
 

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -140,14 +140,14 @@ def prepare_rocm_plugin_wheel(rocm_sources_path: pathlib.Path, *, cpu, rocm_vers
 
     shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
     runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib"
-    # patchelf --force-rpath --set-rpath $RUNPATH $so
+    # patchelf --set-rpath $RUNPATH $so
     fix_perms = False
     perms = os.stat(shared_obj_path).st_mode
     if not perms & stat.S_IWUSR:
         fix_perms = True
         os.chmod(shared_obj_path, perms | stat.S_IWUSR)
     subprocess.check_call(
-        ["patchelf", "--force-rpath", "--set-rpath", runpath, shared_obj_path]
+        ["patchelf", "--set-rpath", runpath, shared_obj_path]
     )
     if fix_perms:
         os.chmod(shared_obj_path, perms)

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -16,6 +16,7 @@
 # as part of the jax cuda/rocm plugin build process.
 
 # Most users should not run this script directly; use build.py instead.
+# pylint: disable=duplicate-code
 
 """
 Script to build a JAX ROCm plugin wheel. Intended for use via Bazel.

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -129,7 +129,7 @@ def prepare_rocm_plugin_wheel(sources_path: pathlib.Path, *, cpu, rocm_version):
     raise Exception(mesg) from ex
 
   shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
-  runpath = '$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib'
+  runpath = '$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib'
   # patchelf --force-rpath --set-rpath $RUNPATH $so
   fix_perms = False
   perms = os.stat(shared_obj_path).st_mode

--- a/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
+++ b/jax_rocm_plugin/pjrt/tools/build_gpu_plugin_wheel.py
@@ -17,6 +17,12 @@
 
 # Most users should not run this script directly; use build.py instead.
 
+# pylint: disable=R0801
+
+"""
+Script to build a JAX ROCm plugin wheel. Intended for use via Bazel.
+"""
+
 import argparse
 import functools
 import os
@@ -25,9 +31,12 @@ import stat
 import subprocess
 import tempfile
 
+# pylint: disable=import-error
 from bazel_tools.tools.python.runfiles import runfiles
 from pjrt.tools import build_utils
 
+
+# pylint: disable=R0801
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--sources_path",
@@ -62,112 +71,117 @@ parser.add_argument(
     help="Create an 'editable' jax cuda/rocm plugin build instead of a wheel.",
 )
 parser.add_argument(
-    "--enable-rocm",
-    default=False,
-    help="Should we build with ROCM enabled?")
+    "--enable-rocm", default=False, help="Should we build with ROCM enabled?"
+)
 args = parser.parse_args()
+# pylint: enable=R0801
 
 r = runfiles.Create()
 
 
-def write_setup_cfg(sources_path, cpu):
-  tag = build_utils.platform_tag(cpu)
-  with open(sources_path / "setup.cfg", "w") as f:
-    f.write(
-        f"""[metadata]
+def write_setup_cfg(setup_cfg_path, cpu):
+    """Write setup.cfg with platform tag."""
+    tag = build_utils.platform_tag(cpu)
+    with open(setup_cfg_path / "setup.cfg", "w", encoding="utf-8") as f:
+        f.write(
+            f"""[metadata]
 license_files = LICENSE.txt
 
 [bdist_wheel]
 plat_name={tag}
 python-tag=py3
 """
+        )
+
+
+def prepare_rocm_plugin_wheel(rocm_sources_path: pathlib.Path, *, cpu, rocm_version):
+    """Assembles a source tree for the ROCm wheel in `rocm_sources_path`."""
+    copy_runfiles = functools.partial(build_utils.copy_file, runfiles=r)
+
+    plugin_dir = rocm_sources_path / "jax_plugins" / f"xla_rocm{rocm_version}"
+    copy_runfiles(
+        dst_dir=rocm_sources_path,
+        src_files=[
+            "__main__/pjrt/python/pyproject.toml",
+            "__main__/pjrt/python/setup.py",
+        ],
+    )
+    build_utils.update_setup_with_rocm_version(rocm_sources_path, rocm_version)
+    write_setup_cfg(rocm_sources_path, cpu)
+    copy_runfiles(
+        dst_dir=plugin_dir,
+        src_files=[
+            "__main__/pjrt/python/__init__.py",
+            "__main__/pjrt/python/version.py",
+        ],
+    )
+    copy_runfiles(
+        "__main__/pjrt/pjrt_c_api_gpu_plugin.so",
+        dst_dir=plugin_dir,
+        dst_filename="xla_rocm_plugin.so",
     )
 
+    # NOTE(mrodden): this is a hack to change/set rpath values
+    # in the shared objects that are produced by the bazel build
+    # before they get pulled into the wheel build process.
+    # we have to do this change here because setting rpath
+    # using bazel requires the rpath to be valid during the build
+    # which won't be correct until we make changes to
+    # the xla/tsl/jax plugin build
 
-def prepare_rocm_plugin_wheel(sources_path: pathlib.Path, *, cpu, rocm_version):
-  """Assembles a source tree for the ROCm wheel in `sources_path`."""
-  copy_runfiles = functools.partial(build_utils.copy_file, runfiles=r)
+    try:
+        subprocess.check_output(["which", "patchelf"])
+    except subprocess.CalledProcessError as ex:
+        mesg = (
+            "rocm plugin and kernel wheel builds require patchelf. "
+            "please install 'patchelf' and run again"
+        )
+        raise RuntimeError(mesg) from ex
 
-  plugin_dir = sources_path / "jax_plugins" / f"xla_rocm{rocm_version}"
-  copy_runfiles(
-      dst_dir=sources_path,
-      src_files=[
-          "__main__/pjrt/python/pyproject.toml",
-          "__main__/pjrt/python/setup.py",
-      ],
-  )
-  build_utils.update_setup_with_rocm_version(sources_path, rocm_version)
-  write_setup_cfg(sources_path, cpu)
-  copy_runfiles(
-      dst_dir=plugin_dir,
-      src_files=[
-          "__main__/pjrt/python/__init__.py",
-          "__main__/pjrt/python/version.py",
-      ],
-  )
-  copy_runfiles(
-      "__main__/pjrt/pjrt_c_api_gpu_plugin.so",
-      dst_dir=plugin_dir,
-      dst_filename="xla_rocm_plugin.so",
-  )
-
-  # NOTE(mrodden): this is a hack to change/set rpath values
-  # in the shared objects that are produced by the bazel build
-  # before they get pulled into the wheel build process.
-  # we have to do this change here because setting rpath
-  # using bazel requires the rpath to be valid during the build
-  # which won't be correct until we make changes to
-  # the xla/tsl/jax plugin build
-
-  try:
-    subprocess.check_output(["which", "patchelf"])
-  except subprocess.CalledProcessError as ex:
-    mesg = (
-        "rocm plugin and kernel wheel builds require patchelf. "
-        "please install 'patchelf' and run again"
+    shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
+    runpath = "$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib"
+    # patchelf --force-rpath --set-rpath $RUNPATH $so
+    fix_perms = False
+    perms = os.stat(shared_obj_path).st_mode
+    if not perms & stat.S_IWUSR:
+        fix_perms = True
+        os.chmod(shared_obj_path, perms | stat.S_IWUSR)
+    subprocess.check_call(
+        ["patchelf", "--force-rpath", "--set-rpath", runpath, shared_obj_path]
     )
-    raise Exception(mesg) from ex
-
-  shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
-  runpath = '$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib:/opt/rocm/lib'
-  # patchelf --force-rpath --set-rpath $RUNPATH $so
-  fix_perms = False
-  perms = os.stat(shared_obj_path).st_mode
-  if not perms & stat.S_IWUSR:
-      fix_perms = True
-      os.chmod(shared_obj_path, perms | stat.S_IWUSR)
-  subprocess.check_call(["patchelf", "--force-rpath", "--set-rpath", runpath, shared_obj_path])
-  if fix_perms:
-      os.chmod(shared_obj_path, perms)
+    if fix_perms:
+        os.chmod(shared_obj_path, perms)
 
 
-tmpdir = None
-sources_path = args.sources_path
-if sources_path is None:
-  tmpdir = tempfile.TemporaryDirectory(prefix="jaxgpupjrt")
-  sources_path = tmpdir.name
+def main():
+    """Main entry point for building the ROCm plugin wheel."""
+    sources_path = args.sources_path
+    with tempfile.TemporaryDirectory(prefix="jaxgpupjrt") as tmpdir:
+        if sources_path is None:
+            sources_path = tmpdir
+        os.makedirs(args.output_path, exist_ok=True)
 
-try:
-  os.makedirs(args.output_path, exist_ok=True)
+        if args.enable_rocm:
+            prepare_rocm_plugin_wheel(
+                pathlib.Path(sources_path),
+                cpu=args.cpu,
+                rocm_version=args.platform_version,
+            )
+            package_name = "jax rocm plugin"
+        else:
+            raise ValueError("Unsupported backend. Choose 'rocm'.")
 
-  if args.enable_rocm:
-    prepare_rocm_plugin_wheel(
-        pathlib.Path(sources_path), cpu=args.cpu, rocm_version=args.platform_version
-    )
-    package_name = "jax rocm plugin"
-  else:
-    raise ValueError("Unsupported backend. Choose 'rocm'.")
+        if args.editable:
+            build_utils.build_editable(sources_path, args.output_path, package_name)
+        else:
+            git_hash = build_utils.get_githash(args.jaxlib_git_hash)
+            build_utils.build_wheel(
+                sources_path,
+                args.output_path,
+                package_name,
+                git_hash=git_hash,
+            )
 
-  if args.editable:
-    build_utils.build_editable(sources_path, args.output_path, package_name)
-  else:
-    git_hash = build_utils.get_githash(args.jaxlib_git_hash)
-    build_utils.build_wheel(
-        sources_path,
-        args.output_path,
-        package_name,
-        git_hash=git_hash,
-    )
-finally:
-  if tmpdir:
-    tmpdir.cleanup()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

When testing the built 0.6.0 wheels for DLM e2e workloads, the jax_nlp_seq gives the following error:
```
jaxlib.xla_extension.XlaRuntimeError: INTERNAL: Failed to open /opt/venv/lib/python3.12/site-packages/jax_plugins/xla_rocm7/xla_rocm_plugin.so: librccl.so.1: cannot open shared object file: No such file or directory
E0926 14:22:41.853117 140424214503552 xla_bridge.py:566] Jax plugin configuration error: Exception when calling jax_plugins.xla_rocm7.initialize()
```

## Technical Details

The reason for this error is that the wheel rpath is missing /opt/rocm/lib path which contains the .so files. Therefore, the library is not found. 
To fix this, this PR adds the /opt/rocm/lib to the wheel rpath. 

## Test Plan

This was tested using DLM jax_nlp_seq and other workloads as well.

## Test Result

The newly built wheels do not have this error. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
