### PR TITLE
Bump JAX pin to latest rocm-jaxlib-v0.9.1

### DIFF
--- a/jax_rocm_plugin/third_party/jax/workspace.bzl
+++ b/jax_rocm_plugin/third_party/jax/workspace.bzl
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update JAX_COMMIT below
 
-JAX_COMMIT = "7f75782ad5ea6cd97e6346dcae9317ac31babef8"
+JAX_COMMIT = "0dd06959d9c49a606a7ad83f8430152fded3d7e9"
 
 def repo():
     git_repository(


### PR DESCRIPTION
## Summary

Bump `JAX_COMMIT` in `jax_rocm_plugin/third_party/jax/workspace.bzl` to the current tip of `ROCm/jax` `rocm-jaxlib-v0.9.1`.

- Old: `7f75782ad5ea6cd97e6346dcae9317ac31babef8`
- New: `0dd06959d9c49a606a7ad83f8430152fded3d7e9`

## Picks up the following ROCm/jax commits

- `0dd06959d9` [ROCm][Pallas] Skip fused attention bwd tests that exceed device resources (#802)
- `d0a887e95b` Remove outdated ROCm skip that depends on ROCm versions < 6.4 (#776)
- `66ca90c3db` Skip failing tests (#772)
- `ad46b2202a` Cherry-pick test updates. (#771)
- `594e74d15b` Fix visibility in BUILD files (#757)