### PR TITLE
Update JAX_COMMIT and XLA_COMMIT to new commit hashes

### DIFF
--- a/jax_rocm_plugin/third_party/jax/workspace.bzl
+++ b/jax_rocm_plugin/third_party/jax/workspace.bzl
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.2 branch)
 #   2. Update JAX_COMMIT below
 
-JAX_COMMIT = "e858823873a87b02e3e551223985c7b63dad4d58"
+JAX_COMMIT = "53ae1b7b02a411c37d9e7ff1539b2ecfc33337ad"
 
 def repo():
     git_repository(

--- a/jax_rocm_plugin/third_party/xla/workspace.bzl
+++ b/jax_rocm_plugin/third_party/xla/workspace.bzl
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.2 branch)
 #   2. Update XLA_COMMIT below
 
-XLA_COMMIT = "f7d005c57fcaac805e79f911153ab748e73f0fa6"
+XLA_COMMIT = "5e31076eef4b49f5470e0f70773207002125ac7d"
 
 def repo():
     git_repository(


### PR DESCRIPTION
Update jax hash and xla hash

- Updated `JAX_COMMIT` to new commit hash
- Updated `XLA_COMMIT` to `5e31076eef4b49f5470e0f70773207002125ac7d` in `jax_rocm_plugin/third_party/xla/workspace.bzl`