### PR TITLE
Bump JAX pin to latest rocm-jaxlib-v0.9.1

### DIFF
--- a/jax_rocm_plugin/third_party/jax/workspace.bzl
+++ b/jax_rocm_plugin/third_party/jax/workspace.bzl
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 #   1. Find the commit hash you want to pin to (e.g., from rocm-jaxlib-v0.9.1 branch)
 #   2. Update JAX_COMMIT below
 
-JAX_COMMIT = "0dd06959d9c49a606a7ad83f8430152fded3d7e9"
+JAX_COMMIT = "61855905404f1deca52b290889f56f141fcc554a"
 
 def repo():
     git_repository(


### PR DESCRIPTION
Update JAX_COMMIT in jax_rocm_plugin/third_party/jax/workspace.bzl from
0dd06959d9c49a606a7ad83f8430152fded3d7e9 to
61855905404f1deca52b290889f56f141fcc554a (tip of ROCm/jax rocm-jaxlib-v0.9.1).

Picks up the following ROCm/jax commit:
- 6185590540 Revert "Fix visibility in BUILD files" (#803)