### PR TITLE
[CI] Update runner labels to amd-do-linux.rocm-jax.gpu.gfx950.1

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -57,7 +57,7 @@ jobs:
         install-llvm: [true, false]
         include:
           - rocm-version: "7.2.0"
-            runner-label: "linux-x86-64-1gpu-amd"
+            runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
     steps:
       - name: Clean up old runs
         run: |
@@ -160,7 +160,7 @@ jobs:
         install-llvm: [true, false]
         therock-version: ["", "7.13.0"]
         include:
-          - runner-label: "linux-x86-64-1gpu-amd"
+          - runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
           - therock-version: ""
             therock-index-url: "https://rocm.nightlies.amd.com/whl-multi-arch/"
           - therock-version: "7.13.0"
@@ -252,7 +252,7 @@ jobs:
       inputs.image-set == 'therock' ||
       inputs.image-set == 'both'
     name: "TheRock ${{ matrix.therock-version || 'latest' }}, manylinux"
-    runs-on: linux-x86-64-1gpu-amd
+    runs-on: amd-do-linux.rocm-jax.gpu.gfx950.1
     strategy:
       fail-fast: false
       matrix:
@@ -349,7 +349,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: "linux-x86-64-1gpu-amd"
+            runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
     steps:
       - name: Clean up old runs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
-      runner-label: '["linux-x86-64-1gpu-amd"]'
+      runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
   run-python-unit-tests:
     name: run-python-unit-tests (deprecated)
     needs: call-build-docker

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: '["linux-x86-64-1gpu-amd"]'
+            runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
     uses: ./.github/workflows/build-wheels.yml
     with:
       python-versions: "3.11,3.12,3.13,3.14"
@@ -44,7 +44,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: '["linux-x86-64-1gpu-amd"]'
+            runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}


### PR DESCRIPTION
## Summary

- Replace `linux-x86-64-1gpu-amd` runner label with `amd-do-linux.rocm-jax.gpu.gfx950.1` across all CI workflows
- Affects `build-base-docker.yml`, `ci.yml`, and `nightly.yml`

## Test plan

- [x] Verify CI jobs pick up the correct runner after merge
- [ ] Confirm no jobs fail due to runner unavailability