### PR TITLE
Clean up single-arch references and device arch arg in Rock manylinux.

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -1,12 +1,12 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 ### Container Build Arguments:
-# TheRock nightly index URL (GPU-family-specific).
-ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
+# TheRock nightly multi-arch index URL.
+ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/whl-multi-arch/
 # TheRock version number (e.g. "7.13.0a20260401" or "" for latest).
 ARG THEROCK_VERSION=""
 # GPU architecture / device family (selects the rocm[device-<arch>] extra).
-ARG GFX_ARCH=gfx950
+ARG GFX_ARCH=device-gfx950
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel,device-${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
+        "rocm[libraries,devel,${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
     rocm-sdk init
 


### PR DESCRIPTION
## Motivation
As per the discussion in https://github.com/ROCm/rocm-jax/pull/470, this PR does some more cleanup on TheRock manylinux image.

- It refines the arch arg to take `device-gfx<ARCH>` instead of `gfx<ARCH>` so that a comma separated list of devices can be passed to TheRock pip install.

- It cleans up old references to the single-arch Rock index.

## Changes
All changes are contained to `docker/manylinux/Dockerfile.jax-manylinux_2_28-therock`