### PR TITLE
Add --therock-index-url support to build/ci_build so 0.9.1 wheels can build against TheRock pip indexes

### DIFF
--- a/build/ci_build
+++ b/build/ci_build
@@ -129,12 +129,12 @@ def _docker_image_exists(image):
     return True
 
 
-def _construct_manylinux_builder_image_name(rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None):
+def _construct_manylinux_builder_image_name(rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None, therock_index_url=None):
     """Create an image name that includes the ROCm ersion, build job, build number, etc"""
     sanitized_version = rocm_version.replace("+", ".")
     return "{base_name}-{rocm_type}-{rocm_version}{rocm_build_job}{rocm_build_num}".format(
         base_name=MANYLINUX_IMAGE_BASE_NAME,
-        rocm_type="therock" if therock_path else "rocm",
+        rocm_type="therock" if (therock_path or therock_index_url) else "rocm",
         rocm_version=sanitized_version,
         rocm_build_job="-%s" % rocm_build_job if rocm_build_job else "",
         rocm_build_num="-%s" % rocm_build_num if rocm_build_num else "",
@@ -142,15 +142,30 @@ def _construct_manylinux_builder_image_name(rocm_version, rocm_build_job="", roc
 
 
 def build_manylinux_dockers(
-    rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None, tag=None
+    rocm_version, rocm_build_job="", rocm_build_num="", therock_path=None, tag=None,
+    therock_index_url=None, therock_version="", therock_gfx_arch=None,
 ):
     """Build a manylinux image that can be used for building release-ready JAX wheels"""
     if tag:
         constructed_tag = tag
     else:
-        constructed_tag = _construct_manylinux_builder_image_name(rocm_version, rocm_build_job, rocm_build_num, therock_path)
+        constructed_tag = _construct_manylinux_builder_image_name(rocm_version, rocm_build_job, rocm_build_num, therock_path, therock_index_url)
 
-    if therock_path:
+    if therock_index_url:
+        # Install ROCm from a TheRock pip index (e.g. the multi-arch index).
+        cmd = [
+            "docker",
+            "build",
+            "-t=%s" % constructed_tag,
+            "--file=docker/manylinux/Dockerfile.jax-manylinux_2_28-therock",
+            "--build-arg=ROCM_VERSION=%s" % rocm_version,
+            "--build-arg=THEROCK_INDEX_URL=%s" % therock_index_url,
+            "--build-arg=THEROCK_VERSION=%s" % therock_version,
+        ]
+        if therock_gfx_arch:
+            cmd.append("--build-arg=GFX_ARCH=%s" % therock_gfx_arch)
+        cmd.append(".")
+    elif therock_path:
         cmd = [
             "docker",
             "build",
@@ -189,6 +204,9 @@ def dist_wheels(
     builder_image=None,
     wheel_post_release=None,
     include_rocm_version_extra=True,
+    therock_index_url=None,
+    therock_version="",
+    therock_gfx_arch=None,
 ):
     jax_plugin_dir = "jax_rocm_plugin"
 
@@ -201,11 +219,14 @@ def dist_wheels(
             rocm_build_job=rocm_build_job,
             rocm_build_num=rocm_build_num,
             therock_path=therock_path,
+            therock_index_url=therock_index_url,
+            therock_version=therock_version,
+            therock_gfx_arch=therock_gfx_arch,
         )
     # If builder-image is set to 'search', try and find one based off of the passed ROCm info
     elif local_builder_image == "search":
         print("Searching for manylinux builder image...")
-        local_builder_image = _construct_manylinux_builder_image_name(rocm_version, rocm_build_job, rocm_build_num, therock_path)
+        local_builder_image = _construct_manylinux_builder_image_name(rocm_version, rocm_build_job, rocm_build_num, therock_path, therock_index_url)
         if not _docker_image_exists(local_builder_image):
             print(f"ERROR: Builder image '{local_builder_image}' does not exist")
             exit(1)
@@ -240,7 +261,7 @@ def dist_wheels(
     cmd.append("dist_wheels")
 
     env = os.environ.copy()
-    if therock_path:
+    if therock_path or therock_index_url:
         env["THEROCK_BUILD"] = "1"
     subprocess.check_call(cmd, cwd=jax_plugin_dir, env=env)
 
@@ -619,6 +640,24 @@ def parse_args():
     )
 
     p.add_argument(
+        "--therock-index-url",
+        default="",
+        help="TheRock pip index URL (e.g. https://rocm.nightlies.amd.com/whl-multi-arch/). When set, ROCm is pip-installed from this index instead of a tarball. Mutually exclusive with --therock-path, --rocm-build-job, and --rocm-build-num.",
+    )
+
+    p.add_argument(
+        "--therock-version",
+        default="",
+        help="Optional TheRock version pin for --therock-index-url (e.g. 7.14.0a20260623). Defaults to latest.",
+    )
+
+    p.add_argument(
+        "--therock-gfx-arch",
+        default="",
+        help="GPU device extra to pull for --therock-index-url (selects rocm[device-<arch>], e.g. device-gfx950).",
+    )
+
+    p.add_argument(
         "--xla-source-dir",
         help="Path to XLA source to use during plugin and jaxlib build, instead of builtin XLA",
     )
@@ -713,6 +752,16 @@ def parse_args():
             "You cannot set both --therock-path and --rocm-build-job/--rocm-build-num."
         )
 
+    # --therock-index-url is its own ROCm source; it cannot be combined with the
+    # tarball flow or the internal dev-build (Jenkins) flow.
+    if args.therock_index_url and (
+        args.therock_path or args.rocm_build_job or args.rocm_build_num
+    ):
+        p.error(
+            "You cannot set --therock-index-url together with --therock-path or "
+            "--rocm-build-job/--rocm-build-num."
+        )
+
     # Note: --rocm-build-job can be used alone - build_num will be auto-fetched
     # from Jenkins. But --rocm-build-num requires --rocm-build-job.
     if args.rocm_build_num and not args.rocm_build_job:
@@ -731,6 +780,9 @@ def main():
             rocm_build_num=args.rocm_build_num,
             therock_path=args.therock_path,
             tag=args.tag,
+            therock_index_url=args.therock_index_url,
+            therock_version=args.therock_version,
+            therock_gfx_arch=args.therock_gfx_arch,
         )
 
     if args.action == "dist_wheels":
@@ -747,6 +799,9 @@ def main():
             builder_image=args.builder_image,
             wheel_post_release=args.wheel_post_release,
             include_rocm_version_extra=not args.no_rocm_version_extra,
+            therock_index_url=args.therock_index_url,
+            therock_version=args.therock_version,
+            therock_gfx_arch=args.therock_gfx_arch,
         )
 
     if args.action == "build_dockers":

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -1,19 +1,48 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
-
+### Container Build Arguments:
+# ROCm version, used to name the tarball install location (/opt/rocm-<version>).
 ARG ROCM_VERSION
-ARG THEROCK_PATH
+# URL of (or local path to) a flat TheRock release tarball to install. Used by
+# the legacy single-arch tarball flow (mutually exclusive with THEROCK_INDEX_URL).
+ARG THEROCK_PATH=""
+# TheRock pip index URL (e.g. https://rocm.nightlies.amd.com/whl-multi-arch/).
+# When set, ROCm is installed via pip from this index instead of a tarball.
+ARG THEROCK_INDEX_URL=""
+# Optional TheRock version pin for the pip flow (e.g. "7.14.0a20260623").
+ARG THEROCK_VERSION=""
+# GPU device extra to pull for the pip flow (selects rocm[device-<arch>]).
+ARG GFX_ARCH=device-gfx950
 ENV GPU_DEVICE_TARGETS="gfx906 gfx908 gfx90a gfx9-4-generic gfx10-3-generic gfx11-generic gfx12-generic"
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y patchelf numactl-devel vim-common
 
-# Install ROCm
+# Install ROCm. Two modes:
+#   1. THEROCK_INDEX_URL set -> pip install the multi-arch rocm[...] packages and
+#      symlink /opt/rocm to the SDK root reported by `rocm-sdk path --root`. The
+#      symlink keeps this branch's /opt/rocm-based build plumbing
+#      (build_wheels.py / build.py) working without a full refactor.
+#   2. otherwise -> download and unpack a flat TheRock tarball via get_rocm.py.
+# manylinux_2_28's system python3 (3.6) lacks pip, so the pip flow uses a
+# /opt/python/ interpreter and puts its rocm-sdk on PATH (build plumbing only).
 RUN --mount=type=cache,target=/var/cache/dnf \
+    --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=./tools/get_rocm.py,target=get_rocm.py \
-    python3 get_rocm.py --rocm-version=$ROCM_VERSION --therock-path=$THEROCK_PATH
+    if [ -n "${THEROCK_INDEX_URL}" ]; then \
+        /opt/python/cp312-cp312/bin/python3 -m pip install \
+            --pre --index-url "${THEROCK_INDEX_URL}" \
+            "rocm[libraries,devel,${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
+        ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
+        rocm-sdk init && \
+        ln -sfn "$(rocm-sdk path --root)" /opt/rocm; \
+    else \
+        python3 get_rocm.py --rocm-version=$ROCM_VERSION --therock-path=$THEROCK_PATH; \
+    fi
+ENV ROCM_HOME=/opt/rocm
 ENV PATH="$PATH:/opt/rocm/bin:/opt/rocm/llvm/bin"
+ENV LD_LIBRARY_PATH="/opt/rocm/lib"
 RUN printf '%s\n' > /opt/rocm/bin/target.lst ${GPU_DEVICE_TARGETS}
 
 # Install LLVM 18 and dependencies.
@@ -23,11 +52,16 @@ RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/a
     mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
     make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
 
-# Copy in our clang configuiration file
-COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
-COPY ./docker/manylinux/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
-COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
-COPY ./docker/manylinux/clang.cfg /opt/rocm/llvm/bin/clang.cfg
+# Copy in our clang configuration file. The /opt/rocm/llvm/bin copies only apply
+# to layouts that ship a bundled LLVM (the tarball flow); guard them so the pip
+# flow (where /opt/rocm/llvm/bin may not exist) does not fail.
+COPY ./docker/manylinux/clang.cfg /tmp/clang.cfg
+RUN cp /tmp/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg && \
+    cp /tmp/clang.cfg /usr/lib/llvm-18/bin/clang.cfg && \
+    if [ -d /opt/rocm/llvm/bin ]; then \
+        cp /tmp/clang.cfg /opt/rocm/llvm/bin/clang++.cfg && \
+        cp /tmp/clang.cfg /opt/rocm/llvm/bin/clang.cfg; \
+    fi
 
 # Install AWS CLI v2
 RUN --mount=type=cache,target=/var/cache/dnf \
@@ -38,3 +72,8 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     rm -rf /tmp/aws /tmp/awscliv2.zip && \
     dnf clean all
 
+LABEL com.amdgpu.therock_path="$THEROCK_PATH" \
+      com.amdgpu.therock_index_url="$THEROCK_INDEX_URL" \
+      com.amdgpu.therock_version="$THEROCK_VERSION" \
+      com.amdgpu.gfx_arch="$GFX_ARCH" \
+      com.amdgpu.rocm_version="$ROCM_VERSION"


### PR DESCRIPTION
## Motivation

Adds a pip-index ROCm install path to the rocm-jaxlib-v0.9.1 wheel build so JAX wheels can be built against TheRock's pip indexes  including the multi-arch index (https://rocm.nightlies.amd.com/whl-multi-arch/) instead of only flat tarballs.

Previously 0.9.1's only ROCm sources were flat tarballs (--therock-path), internal Jenkins dev builds, and repo.radeon.com packages. The multi-arch wheel index is published only as pip packages (no flat tarball), so feeding it to --therock-path failed at the target.lst step. This change makes the multi-arch (and single-arch) wheel indexes consumable.

## Technical Details

- build/ci_build: new --therock-index-url, --therock-version, and --therock-gfx-arch flags, threaded through dist_wheels → build_manylinux_dockers → docker build --build-arg. Added mutual-exclusivity with --therock-path / --rocm-build-job / --rocm-build-num, and THEROCK_BUILD=1 is set for the index flow.
- docker/manylinux/Dockerfile.jax-manylinux_2_28-therock: made dual-mode: when THEROCK_INDEX_URL is set, pip install --index-url <index> "rocm[libraries,devel,<gfx>]", run rocm-sdk init, and symlink /opt/rocm to $(rocm-sdk path --root); otherwise fall back to the existing get_rocm.py tarball flow. The clang.cfg copy into /opt/rocm/llvm/bin is now guarded so the pip layout (no bundled LLVM there) doesn't fail.
- The /opt/rocm symlink is intentionally 0.9.1-only: this branch's build (build_wheels.py / build.py + post-build patchelf) is hardwired to /opt/rocm, so the symlink lets it consume the pip SDK without a refactor. ≥0.10.0 is already /opt/rocm-less via rocm-sdk path --root + link-time RUNPATH and does not need this.

## Test Plan

-  Multi-arch: build/ci_build --therock-index-url=https://rocm.nightlies.amd.com/whl-multi-arch/ --rocm-version=7.14.0 --python-versions="3.11,3.12,3.13,3.14" dist_wheels
-  Single-arch index: same with --therock-index-url=.../v2/gfx94X-dcgpu/ --therock-gfx-arch=device-gfx942
-  Regression: existing --therock-path=<single-arch tarball> build still works
-  Confirm built wheels import and run on the target GPU

## Test Result

All confirmed and working. 
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
