### PR TITLE
Update llama-perf workflow to JAX v0.10.0

### DIFF
--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -1,10 +1,10 @@
 name: Llama Performance Benchmarks
 
 # This workflow runs Llama performance benchmarks
-# using two different JAX versions: 0.6.0 & 0.9.2
+# using two different JAX versions: 0.6.0 & 0.10.0
 # For JAX 0.6.0: uses official released wheels
 # and Docker image.
-# For JAX 0.9.2: uses wheels and Docker image
+# For JAX 0.10.0: uses wheels and Docker image
 # built from the latest nightly results.
 
 # PS: Ubuntu 24 & ROCm 7.2.0.
@@ -42,17 +42,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jax-version: ["0.6.0", "0.9.2"]
+        jax-version: ["0.6.0", "0.10.0"]
         include:
           - jax-version: "0.6.0"
             jaxlib-version: "0.6.0"
             # There is no docker image with ROCm 7.2.0 and Jax 0.6.0
-            # use a ROCm 7.2.0 / Jax 0.9.2 docker image and update Jax
+            # use a ROCm 7.2.0 / Jax 0.10.0 docker image and update Jax
             # before building TE. For the application workload Bazel installs
             # its own Jax
             docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
-          - jax-version: "0.9.2"
-            jaxlib-version: "0.9.2"
+          - jax-version: "0.10.0"
+            jaxlib-version: "0.10.0"
             docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
     env:
       NVTE_FRAMEWORK: jax
@@ -124,13 +124,13 @@ jobs:
                 jaxlib==0.6.0 \
                 "$PJRT_URL" \
                 "$PLUGIN_URL"
-            elif [ "${{ matrix.jax-version }}" == "0.9.2" ]; then
+            elif [ "${{ matrix.jax-version }}" == "0.10.0" ]; then
               apt update
               apt install libdw1 libglib2.0-0
               pip install --force-reinstall \
-                jax==0.9.2 \
-                jax-rocm7-plugin==0.9.2.* \
-                jax-rocm7-pjrt==0.9.2.*
+                jax==0.10.0 \
+                jax-rocm7-plugin==0.10.0.* \
+                jax-rocm7-pjrt==0.10.0.*
             fi
             cd /workspace/transformerengine
             sed -i '\''s/jax\.extend/jax/g'\'' build_tools/jax.py
@@ -152,16 +152,16 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        jax-version: ["0.6.0", "0.9.2"]
+        jax-version: ["0.6.0", "0.10.0"]
         model-name: ["train_dense"]
         include:
           - jax-version: "0.6.0"
             model-name: "train_dense"
             jaxlib-version: "0.6.0"
             docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
-          - jax-version: "0.9.2"
+          - jax-version: "0.10.0"
             model-name: "train_dense"
-            jaxlib-version: "0.9.2"
+            jaxlib-version: "0.10.0"
             docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
     steps:
       - name: Checkout source repo
@@ -178,11 +178,11 @@ jobs:
             "$REL_URL/jax_rocm7_pjrt-0.6.0-py3-none-manylinux_2_28_x86_64.whl"
             curl -L --output-dir wheelhouse -O \
             "$REL_URL/jax_rocm7_plugin-0.6.0-cp312-cp312-manylinux_2_28_x86_64.whl"
-          elif [ "${{ matrix.jax-version }}" == "0.9.2" ]; then
+          elif [ "${{ matrix.jax-version }}" == "0.10.0" ]; then
             mkdir -p wheelhouse
             python3 -m pip download -d wheelhouse \
-              jax_rocm7_pjrt==0.9.2.* \
-              jax_rocm7_plugin==0.9.2.* \
+              jax_rocm7_pjrt==0.10.0.* \
+              jax_rocm7_plugin==0.10.0.* \
               --no-deps
           fi
       - name: Download TE wheel artifact
@@ -286,7 +286,7 @@ jobs:
             model-name: "train_dense"
             rocm-version: "7.2.0"
             python-version: "3.12"
-          - jax-version: "0.9.2"
+          - jax-version: "0.10.0"
             model-name: "train_dense"
             rocm-version: "7.2.0"
             python-version: "3.12"


### PR DESCRIPTION
## Motivation
This updates the llama-perf workflow to use JAX v0.10.0.

## Changes
Changes are contained to `.github/workflows/llama-perf.yml`
