### PR TITLE
Add dynamic pip URL selection to manylinux Dockerfile (v0.10.2)

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -20,8 +20,12 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 # a /opt/python/ build and symlink its rocm-sdk onto PATH (not a /opt/rocm
 # symlink, just build plumbing so `rocm-sdk` is callable below).
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
+    case "${THEROCK_INDEX_URL}" in \
+        *.html) PIP_SRC="--find-links" ;; \
+        *)      PIP_SRC="--index-url" ;; \
+    esac && \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
-        --pre --index-url "${THEROCK_INDEX_URL}" \
+        --pre "${PIP_SRC}" "${THEROCK_INDEX_URL}" \
         "rocm[libraries,devel,${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
     rocm-sdk init


### PR DESCRIPTION
## Summary
Cherry-picks #476 onto the `rocm-jaxlib-v0.10.2` branch.

The manylinux Dockerfile (`docker/manylinux/Dockerfile.jax-manylinux_2_28-therock`)
installs the ROCm meta-package with `--index-url "${THEROCK_INDEX_URL}"`
unconditionally. When TheRock passes a find-links **HTML** page
(e.g. `.../python/index.html`), pip with `--index-url` cannot resolve the
package and fails:

```
ERROR: Could not find a version that satisfies the requirement rocm[devel,device-all,libraries] (from versions: none)
```

This is already fixed on `rocm-jaxlib-v0.10.0` (commit 209ee9ee8, #476) but the
`rocm-jaxlib-v0.10.2` branch was cut before it landed. This PR restores the
`*.html -> --find-links` auto-detection.

## Why
Unblocks the TheRock multi-arch JAX 0.10.2 release cell (ROCm/TheRock#6195),
which failed at the "Build manylinux image" step for exactly this reason.

## Test plan
- [ ] Re-run ROCm/TheRock multi-arch release matrix; v0.10.2 manylinux image builds