### PR TITLE
Fix manylinux python symlink (base image dropped python3.11)

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -39,7 +39,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # The manylinux base image provides python3 but not unversioned 'python'.
 # CI scripts currently require this so we symlink Python to Python3.
-RUN ln -s /usr/bin/python3.11 /usr/local/bin/python
+RUN ln -s /usr/bin/python3.12 /usr/local/bin/python
 
 # ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
 # libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in


### PR DESCRIPTION
This PR fixes the ROCm 7.2.0 manylinux build failure with `/bin/sh: python: command not found`.

The issue comes from the image `quay.io/pypa/manylinux_2_28_x86_64`, where `/usr/bin/python3.11` was removed in the 2026.06.28 release. See https://quay.io/repository/pypa/manylinux_2_28_x86_64?tab=tags&tag=latest.

Following the approach in https://github.com/ROCm/rocm-jax/pull/379, this change updates the symlink to `python3.12`.