### PR TITLE
Override system python3 in manylinux containers

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -39,7 +39,8 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # The manylinux base image provides python3 but not unversioned 'python'.
 # CI scripts currently require this so we symlink Python to Python3.
-RUN ln -s /usr/bin/python3.12 /usr/local/bin/python
+RUN ln -s /usr/bin/python3.12 /usr/local/bin/python && \
+    ln -s /usr/bin/python3.12 /usr/local/bin/python3
 
 # ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
 # libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -27,6 +27,7 @@ RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     rocm-sdk init
 
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python && \
+    ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python3 && \
     python -m ensurepip && python -m pip install auditwheel
 
 # Install LLVM 18 from source (manylinux has no apt):


### PR DESCRIPTION
## Summary
- Symlink a modern Python to `/usr/local/bin/python3` in both manylinux_2_28 container images (ROCm and TheRock)
- The manylinux_2_28 base image (AlmaLinux 8) ships Python 3.6 as `python3`, which lacks `typing.TypedDict` (added in 3.8)
- Third-party CI actions (e.g. `google-ml-infra/actions/ci_connection`) run `which python3` and fail with `ImportError: cannot import name 'TypedDict'`
