### PR TITLE
Move to cpu runners

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -82,7 +82,7 @@ jobs:
         install-llvm: [true, false]
         include:
           - rocm-version: "7.2.0"
-            runner-label: "amd-do-linux.jax.gpu.gfx950.1"
+            runner-label: "amd-do-linux.jax.cpu"
     steps:
       - name: Clean up old runs
         run: |
@@ -186,7 +186,7 @@ jobs:
         install-llvm: [true, false]
         therock: ${{ fromJSON(needs.therock-config.outputs.entries) }}
         include:
-          - runner-label: "amd-do-linux.jax.gpu.gfx950.1"
+          - runner-label: "amd-do-linux.jax.cpu"
     steps:
       - name: Clean up old runs
         run: |
@@ -275,7 +275,7 @@ jobs:
       inputs.image-set == 'therock' ||
       inputs.image-set == 'both'
     name: "TheRock ${{ matrix.therock.therock-version || 'latest' }}, manylinux"
-    runs-on: amd-do-linux.jax.gpu.gfx950.1
+    runs-on: amd-do-linux.jax.cpu
     strategy:
       fail-fast: false
       matrix:
@@ -367,7 +367,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: "amd-do-linux.jax.gpu.gfx950.1"
+            runner-label: "amd-do-linux.jax.cpu"
     steps:
       - name: Clean up old runs
         run: |

--- a/.github/workflows/build_hermetic_ubu24_docker.yml
+++ b/.github/workflows/build_hermetic_ubu24_docker.yml
@@ -20,13 +20,13 @@ on:
     inputs:
       runner-label:
         required: false
-        default: amd-do-linux.jax.gpu.gfx950.1
+        default: amd-do-linux.jax.cpu
         type: string
   workflow_call:
     inputs:
       runner-label:
         required: false
-        default: amd-do-linux.jax.gpu.gfx950.1
+        default: amd-do-linux.jax.cpu
         type: string
 
 permissions:
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build-docker:
-    runs-on: ${{ inputs.runner-label || 'amd-do-linux.jax.gpu.gfx950.1' }}
+    runs-on: ${{ inputs.runner-label || 'amd-do-linux.jax.cpu' }}
     env:
       THEROCK_VERSION: '7.13.0'
       THEROCK_INDEX_URL: 'https://repo.amd.com/rocm/whl/gfx950-dcgpu/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
-      runner-label: '["amd-do-linux.jax.gpu.gfx950.1"]'
+      runner-label: '["amd-do-linux.jax.cpu"]'
   run-python-unit-tests:
     name: run-python-unit-tests (deprecated)
     needs: call-build-docker

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: '["amd-do-linux.jax.gpu.gfx950.1"]'
+            runner-label: '["amd-do-linux.jax.cpu"]'
     uses: ./.github/workflows/build-wheels.yml
     with:
       python-versions: "3.11,3.12,3.13,3.14"
@@ -44,7 +44,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: '["amd-do-linux.jax.gpu.gfx950.1"]'
+            runner-label: '["amd-do-linux.jax.cpu"]'
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}


### PR DESCRIPTION
This should relieve some pressure off GPU runners as GPUs are not required to build docker images