### PR TITLE
[release] TheRock 7.14 GA images: bump therock-config to 7.14 GA

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -41,9 +41,7 @@ jobs:
   therock-config:
     # Single source of truth for the TheRock ROCm version + pip index, consumed
     # by both the base and manylinux TheRock jobs so they can't drift.
-    # TODO: when TheRock 7.14 is GA, bump the pinned entry to the final version
-    # and switch its index back to https://repo.amd.com/rocm/whl-multi-arch/
-    # (the prereleases index is for rc builds only).
+    # Pinned to TheRock 7.14 GA, served from the stable repo.amd.com index.
     if: >-
       github.event_name != 'workflow_dispatch' ||
       inputs.image-set == 'therock' ||
@@ -55,11 +53,11 @@ jobs:
       - id: set
         run: |
           NIGHTLY="https://rocm.nightlies.amd.com/whl-multi-arch/"
-          PREREL="https://rocm.prereleases.amd.com/whl-multi-arch/"
+          GA="https://repo.amd.com/rocm/whl-multi-arch/"
           {
             echo 'entries<<JSON'
             echo "[{\"therock-version\": \"\", \"therock-index-url\": \"$NIGHTLY\"},"
-            echo " {\"therock-version\": \"7.14.0rc3\", \"therock-index-url\": \"$PREREL\"}]"
+            echo " {\"therock-version\": \"7.14\", \"therock-index-url\": \"$GA\"}]"
             echo 'JSON'
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
TheRock 7.14 is now GA. Bump the single-source-of-truth `therock-config` entry in `build-base-docker.yml` from the `7.14.0rc3` prerelease to `7.14` GA, and switch its pip index from `rocm.prereleases.amd.com/whl-multi-arch/` back to the stable `repo.amd.com/rocm/whl-multi-arch/`. Both the TheRock base/dev and manylinux jobs consume this entry, so this one change republishes the `jax-manylinux_2_28-therock-7.14` (+ base/dev) images against GA.

This is the GA follow-up to #485 (which introduced `therock-config` for rc3) and clears the "when 7.14 is GA" TODO left there.

Note: `rocm==7.14` resolves to the published GA `7.14.0` under PEP 440. The manylinux Dockerfile needs no change (the workflow passes `--therock-index-url`/`--therock-version`, overriding its default ARG).

## Test plan
- [x] `therock` (or `both`) run of build-base-docker publishes `ghcr.io/rocm/jax-manylinux_2_28-therock-7.14:{latest,<sha>,7.14}` and the therock base/dev images from the GA index.
- [x] Downstream ROCm/jax `wheel_tests_rocm_release` (bumped to `therock-7.14`) goes green against the republished image.