### PR TITLE
Add support for taking multiple arch values in TheRock testing dockerfile

### DIFF
--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -1,10 +1,12 @@
 FROM ubuntu:24.04
 
 ### Container Build Arguments:
-# TheRock nightly index URL (GPU-family-specific).
-ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
+# TheRock nightly multi-arch index URL.
+ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/whl-multi-arch/
 # TheRock version number (e.g. "7.13.0a20260401" or "" for latest).
 ARG THEROCK_VERSION=""
+# GPU architecture / device family (selects the rocm[device-<arch>] extra).
+ARG GFX_ARCH=device-gfx942,device-gfx950
 # Enable LLVM install.
 ARG INSTALL_LLVM=0
 # Version of LLVM to be installed.
@@ -51,7 +53,7 @@ RUN apt-get update && \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     python3 -m pip install --break-system-packages \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel,device-gfx950]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
+        "rocm[libraries,devel,${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     rocm-sdk init
 
 # ROCm/HIP runtime tuning:
@@ -136,6 +138,7 @@ RUN --mount=type=cache,target=/var/cache/apt   \
 
 LABEL com.amdgpu.therock_index_url="$THEROCK_INDEX_URL" \
       com.amdgpu.therock_version="$THEROCK_VERSION" \
+      com.amdgpu.gfx_arch="$GFX_ARCH" \
       com.amdgpu.python_versions="3.11,3.12,3.13,3.13-nogil,3.14,3.14-nogil" \
       com.amdgpu.install_llvm="$INSTALL_LLVM" \
       com.amdgpu.llvm_version="$LLVM_VERSION"


### PR DESCRIPTION
## Motivation
This PR enables TheRock testing dockerfile to take a device arch as an argument. `device-gfx942` and `device-gfx950` have been given as defaults, allowing for testing on a mixed arch RBE cluster with no changes to workflow files.

## Changes
All changes are contained to the testing dockerfile: `docker/Dockerfile.base-therock-ubu24`.