### PR TITLE
Backport Rock CI manylinux dockerfile changes to v0.10.1

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -39,7 +39,8 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # The manylinux base image provides python3 but not unversioned 'python'.
 # CI scripts currently require this so we symlink Python to Python3.
-RUN ln -s /usr/bin/python3.11 /usr/local/bin/python
+RUN ln -s /usr/bin/python3.12 /usr/local/bin/python && \
+    ln -s /usr/bin/python3.12 /usr/local/bin/python3
 
 # ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
 # libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -27,6 +27,7 @@ RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     rocm-sdk init
 
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python && \
+    ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python3 && \
     python -m ensurepip && python -m pip install auditwheel
 
 # Install LLVM 18 from source (manylinux has no apt):

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -20,8 +20,12 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 # a /opt/python/ build and symlink its rocm-sdk onto PATH (not a /opt/rocm
 # symlink, just build plumbing so `rocm-sdk` is callable below).
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
+    case "${THEROCK_INDEX_URL}" in \
+        *.html) PIP_SRC="--find-links" ;; \
+        *)      PIP_SRC="--index-url" ;; \
+    esac && \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
-        --pre --index-url "${THEROCK_INDEX_URL}" \
+        --pre "${PIP_SRC}" "${THEROCK_INDEX_URL}" \
         "rocm[libraries,devel,${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
     rocm-sdk init

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -1,12 +1,12 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 ### Container Build Arguments:
-# TheRock nightly index URL (GPU-family-specific).
-ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/v2/gfx950-dcgpu/
+# TheRock nightly multi-arch index URL.
+ARG THEROCK_INDEX_URL=https://rocm.nightlies.amd.com/whl-multi-arch/
 # TheRock version number (e.g. "7.13.0a20260401" or "" for latest).
 ARG THEROCK_VERSION=""
 # GPU architecture / device family (selects the rocm[device-<arch>] extra).
-ARG GFX_ARCH=gfx950
+ARG GFX_ARCH=device-gfx950
 
 # Install patchelf and headers for numactl
 RUN --mount=type=cache,target=/var/cache/dnf \
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
         --pre --index-url "${THEROCK_INDEX_URL}" \
-        "rocm[libraries,devel,device-${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
+        "rocm[libraries,devel,${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
     rocm-sdk init
 


### PR DESCRIPTION
## Motivation
This PR brings TheRock dockerfile for v0.10.1 up to date with the dockerfile in the default branch. This includes adding support for device-gfx arguments when building, use of the multi-arch wheel index, dynamic pip index URL selection to work with TheRock CI, and updating the Python version used in the dockerfiles.

# Changes
Changes are almost entirely in TheRock dockerfile (`docker/manylinux/Dockerfile.jax-manylinux_2_28-therock`) with a small Python version change in the legacy ROCm dockerfile (`docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm`)