### PR TITLE
Backport dynamic pip URL selection for Rock manylinux dockerfile to v0.11.0

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -20,8 +20,12 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 # a /opt/python/ build and symlink its rocm-sdk onto PATH (not a /opt/rocm
 # symlink, just build plumbing so `rocm-sdk` is callable below).
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
+    case "${THEROCK_INDEX_URL}" in \
+        *.html) PIP_SRC="--find-links" ;; \
+        *)      PIP_SRC="--index-url" ;; \
+    esac && \
     /opt/python/cp312-cp312/bin/python3 -m pip install \
-        --pre --index-url "${THEROCK_INDEX_URL}" \
+        --pre "${PIP_SRC}" "${THEROCK_INDEX_URL}" \
         "rocm[libraries,devel,${GFX_ARCH}]${THEROCK_VERSION:+==}${THEROCK_VERSION}" && \
     ln -sf /opt/python/cp312-cp312/bin/rocm-sdk /usr/local/bin/rocm-sdk && \
     rocm-sdk init


### PR DESCRIPTION
## Motivation
The Rock CI has a pip index URL with a different format than the nightly build index. This PR allows for dynamic selection based on the URL passed in (identified by a *.html suffix). Note: this change is a backport for JAX v0.11.0.

## Changes
Changes contained to `docker/manylinux/Dockerfile.jax-manylinux_2_28-therock`