### PR TITLE
Update llama-perf to JAX 0.10.2 and ROCm 7.14.0

### DIFF
--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -9,7 +9,8 @@ name: Llama Performance Benchmarks
 # Tested on Ubuntu 24 for both wheels
 
 env:
-  TE_REF_DEFAULT: "veergopu/integrate-small-seq-mfma"
+  # veergopu/integrate-small-seq-mfma
+  TE_REF_DEFAULT: "11c9c38bc904b939b6656b539dfedb262dcb616b"
 
 on:
   schedule:
@@ -50,7 +51,8 @@ jobs:
             # before building TE. For the application workload Bazel installs
             # its own Jax
             docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
-            te-ref: "yewang12/small_cross_attn_v2.4"
+            # yewang12/small_cross_attn_v2.4
+            te-ref: "5e87bde39480cd350c4719758c9621edec4dd003"
           - jax-version: "0.10.2"
             jaxlib-version: "0.10.2"
             docker-image: "ghcr.io/rocm/jax-dev-ubu24.therock-7.14:7.14"
@@ -282,6 +284,10 @@ jobs:
             cd /workspace
             bazel version
             apt update && apt install -y libglib2.0-0 libgl1
+            if [ "${{ matrix.jax-version }}" == "0.10.2" ]; then
+              # TheRock has no /opt/rocm; point loader at rocm-sdk libs for libroctx64.
+              export LD_LIBRARY_PATH="$(rocm-sdk path --root)/lib:$LD_LIBRARY_PATH"
+            fi
             export EXECUTOR="base_executor_config"
             export TRAIN_SETTING="${{ matrix.model-name }}"
             export XLA_FLAGS="--xla_gpu_enable_latency_hiding_scheduler=True \

--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -10,7 +10,7 @@ name: Llama Performance Benchmarks
 
 env:
   # veergopu/integrate-small-seq-mfma
-  TE_REF_DEFAULT: "11c9c38bc904b939b6656b539dfedb262dcb616b"
+  TE_REF_DEFAULT: "d003cf5106558d8347dd25ff21698d8551bff8e2"
 
 on:
   schedule:
@@ -132,7 +132,7 @@ jobs:
               # TheRock ships ROCm via the rocm-sdk pip package (no /opt/rocm)
               export ROCM_PATH="$(rocm-sdk path --root)"
               export CMAKE_PREFIX_PATH="${ROCM_PATH}/lib/cmake"
-              # Use the official TheRock 7.14 JAX wheels from the rocm-jax v0.10.2
+              # Use the official TheRock 7.14 JAX wheels from the rocm/jax v0.10.2
               # release. cp312 wheels for the image`s Python 3.12.
               apt install -y unzip wget
               REL="https://github.com/ROCm/rocm-jax/releases/download/rocm-jax-v0.10.2"
@@ -195,7 +195,7 @@ jobs:
             "$REL_URL/jax_rocm7_plugin-0.6.0-cp312-cp312-manylinux_2_28_x86_64.whl"
           elif [ "${{ matrix.jax-version }}" == "0.10.2" ]; then
             mkdir -p wheelhouse
-            # Official TheRock 7.14 JAX wheels from the rocm-jax v0.10.2 release.
+            # Official TheRock 7.14 JAX wheels from the rocm/jax v0.10.2 release.
             REL="https://github.com/ROCm/rocm-jax/releases/download/rocm-jax-v0.10.2"
             curl -L -o wheelhouse_theRock7.14.zip "$REL/wheelhouse_theRock7.14.zip"
             python3 -m zipfile -e wheelhouse_theRock7.14.zip .

--- a/.github/workflows/llama-perf.yml
+++ b/.github/workflows/llama-perf.yml
@@ -1,16 +1,15 @@
 name: Llama Performance Benchmarks
 
 # This workflow runs Llama performance benchmarks
-# using two different JAX versions: 0.6.0 & 0.9.2
+# using two different JAX versions: 0.6.0 & 0.10.2
 # For JAX 0.6.0: uses official released wheels
-# and Docker image.
-# For JAX 0.9.2: uses wheels and Docker image
-# built from the latest nightly results.
-
-# PS: Ubuntu 24 & ROCm 7.2.0.
+# For JAX 0.10.2: uses ROCm 7.14.0 base image from the
+#                   rocm-jax and v0.10.2 GitHub release
+#
+# Tested on Ubuntu 24 for both wheels
 
 env:
-  TE_REF_DEFAULT: "c54e8b2bac2eeed8da6bb45eb7c4764b4e94d538"
+  TE_REF_DEFAULT: "veergopu/integrate-small-seq-mfma"
 
 on:
   schedule:
@@ -42,18 +41,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jax-version: ["0.6.0", "0.9.2"]
+        jax-version: ["0.6.0", "0.10.2"]
         include:
           - jax-version: "0.6.0"
             jaxlib-version: "0.6.0"
             # There is no docker image with ROCm 7.2.0 and Jax 0.6.0
-            # use a ROCm 7.2.0 / Jax 0.9.2 docker image and update Jax
+            # use a ROCm 7.2.0 / Jax 0.10.2 docker image and update Jax
             # before building TE. For the application workload Bazel installs
             # its own Jax
             docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
-          - jax-version: "0.9.2"
-            jaxlib-version: "0.9.2"
-            docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
+            te-ref: "yewang12/small_cross_attn_v2.4"
+          - jax-version: "0.10.2"
+            jaxlib-version: "0.10.2"
+            docker-image: "ghcr.io/rocm/jax-dev-ubu24.therock-7.14:7.14"
     env:
       NVTE_FRAMEWORK: jax
       NVTE_USE_ROCM: 1
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: rocm/transformerengine
-          ref: ${{ inputs.te-ref || env.TE_REF_DEFAULT }}
+          ref: ${{ matrix.te-ref || inputs.te-ref || env.TE_REF_DEFAULT }}
           submodules: recursive
           fetch-depth: 0
           path: transformerengine
@@ -106,7 +106,7 @@ jobs:
           docker exec te-build-jax${{ matrix.jax-version }} bash -lc '
             pip install setuptools ninja pybind11
             pip install cmake==4.1.0
-            pip install packaging psutil
+            pip install packaging psutil pandas
             export NVTE_FRAMEWORK="${{ env.NVTE_FRAMEWORK }}"
             export NVTE_USE_ROCM="${{ env.NVTE_USE_ROCM }}"
             export HIP_PLATFORM="${{ env.HIP_PLATFORM }}"
@@ -124,16 +124,29 @@ jobs:
                 jaxlib==0.6.0 \
                 "$PJRT_URL" \
                 "$PLUGIN_URL"
-            elif [ "${{ matrix.jax-version }}" == "0.9.2" ]; then
+            elif [ "${{ matrix.jax-version }}" == "0.10.2" ]; then
               apt update
               apt install libdw1 libglib2.0-0
-              pip install --force-reinstall \
-                jax==0.9.2 \
-                jax-rocm7-plugin==0.9.2.* \
-                jax-rocm7-pjrt==0.9.2.*
+              # TheRock ships ROCm via the rocm-sdk pip package (no /opt/rocm)
+              export ROCM_PATH="$(rocm-sdk path --root)"
+              export CMAKE_PREFIX_PATH="${ROCM_PATH}/lib/cmake"
+              # Use the official TheRock 7.14 JAX wheels from the rocm-jax v0.10.2
+              # release. cp312 wheels for the image`s Python 3.12.
+              apt install -y unzip wget
+              REL="https://github.com/ROCm/rocm-jax/releases/download/rocm-jax-v0.10.2"
+              wget -q "$REL/wheelhouse_theRock7.14.zip"
+              unzip -o wheelhouse_theRock7.14.zip
+              cd wheelhouse_theRock7.14
+              pip install --force-reinstall jax==0.10.2 \
+                jax_rocm7_pjrt-0.10.2.post1-py3-none-manylinux_2_27_x86_64.whl \
+                jax_rocm7_plugin-0.10.2.post1-cp312-cp312-manylinux_2_27_x86_64.whl
             fi
             cd /workspace/transformerengine
             sed -i '\''s/jax\.extend/jax/g'\'' build_tools/jax.py
+            # importlib.metadata `.files` is None under bazel runfiles; guard the
+            # iteration (TE dev`s PyPI sanity check crashes on NoneType otherwise)
+            INIT=transformer_engine/common/__init__.py
+            sed -i '\''s/te_dist\.files:/(te_dist.files or []):/'\'' "$INIT"
             python3 setup.py bdist_wheel'
       - name: Upload TE wheels artifacts
         uses: actions/upload-artifact@v4
@@ -152,17 +165,17 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        jax-version: ["0.6.0", "0.9.2"]
+        jax-version: ["0.6.0", "0.10.2"]
         model-name: ["train_dense"]
         include:
           - jax-version: "0.6.0"
             model-name: "train_dense"
             jaxlib-version: "0.6.0"
             docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
-          - jax-version: "0.9.2"
+          - jax-version: "0.10.2"
             model-name: "train_dense"
-            jaxlib-version: "0.9.2"
-            docker-image: "ghcr.io/rocm/jax-ubu24.rocm720:nightly"
+            jaxlib-version: "0.10.2"
+            docker-image: "ghcr.io/rocm/jax-dev-ubu24.therock-7.14:7.14"
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v4
@@ -178,12 +191,14 @@ jobs:
             "$REL_URL/jax_rocm7_pjrt-0.6.0-py3-none-manylinux_2_28_x86_64.whl"
             curl -L --output-dir wheelhouse -O \
             "$REL_URL/jax_rocm7_plugin-0.6.0-cp312-cp312-manylinux_2_28_x86_64.whl"
-          elif [ "${{ matrix.jax-version }}" == "0.9.2" ]; then
+          elif [ "${{ matrix.jax-version }}" == "0.10.2" ]; then
             mkdir -p wheelhouse
-            python3 -m pip download -d wheelhouse \
-              jax_rocm7_pjrt==0.9.2.* \
-              jax_rocm7_plugin==0.9.2.* \
-              --no-deps
+            # Official TheRock 7.14 JAX wheels from the rocm-jax v0.10.2 release.
+            REL="https://github.com/ROCm/rocm-jax/releases/download/rocm-jax-v0.10.2"
+            curl -L -o wheelhouse_theRock7.14.zip "$REL/wheelhouse_theRock7.14.zip"
+            python3 -m zipfile -e wheelhouse_theRock7.14.zip .
+            cp wheelhouse_theRock7.14/jax_rocm7_pjrt-*.whl wheelhouse/
+            cp wheelhouse_theRock7.14/jax_rocm7_plugin-*.whl wheelhouse/
           fi
       - name: Download TE wheel artifact
         uses: actions/download-artifact@v4
@@ -204,7 +219,7 @@ jobs:
           echo 'jax==${{ matrix.jax-version }}' >> kylix/third_party/requirements.lock
           echo 'jaxlib==${{ matrix.jaxlib-version }}' >> kylix/third_party/requirements.lock
           PJRT_WHL=$(ls wheelhouse/jax_rocm7_pjrt-*.whl | head -n1 || true)
-          PLUGIN_WHL=$(ls wheelhouse/jax_rocm7_plugin-*.whl | head -n1 || true)
+          PLUGIN_WHL=$(ls wheelhouse/jax_rocm7_plugin-*cp312*.whl | head -n1 || true)
           TE_WHL=$(ls wheelhouse/transformer_engine-*.whl | head -n1 || true)
           PJRT_BASE=$(basename "$PJRT_WHL")
           PLUGIN_BASE=$(basename "$PLUGIN_WHL")
@@ -220,6 +235,17 @@ jobs:
           sed -i '/orbax-checkpoint/ s/^/# /' kylix/third_party/requirements.lock
           echo 'orbax-checkpoint==0.11.25' >> kylix/third_party/requirements.lock
           echo 'aiofiles==25.1.0' >> kylix/third_party/requirements.lock
+          # JAX 0.10 removed the `concrete` option of jax.checkpoint/jax.remat, and
+          # flax <=0.12.0 unconditionally forwards concrete= to jax.remat (breaks the
+          # model`s lifted remat). flax 0.12.7 fixes this but adds a hard dependency
+          # on treescope, which is missing from the resolved lock. Pin both for the
+          # JAX 0.10.2 leg only; the 0.6.0 leg keeps its existing flax.
+          if [ "${{ matrix.jax-version }}" == "0.10.2" ]; then
+            sed -i '/^flax==/ s/^/# /' kylix/third_party/requirements.lock
+            sed -i '/^treescope==/ s/^/# /' kylix/third_party/requirements.lock
+            echo 'flax==0.12.7' >> kylix/third_party/requirements.lock
+            echo 'treescope==0.1.10' >> kylix/third_party/requirements.lock
+          fi
           sed -i '/^wheel/s/^/# /; /^# wheel/a wheel==0.45.1' kylix/third_party/requirements.lock
           sed -i 's/\bfun\s*=\s*self.create_train_step()/self.create_train_step()/g' \
             kylix/max/execution/executors.py
@@ -255,7 +281,7 @@ jobs:
             echo "8.5.0" > /workspace/.bazelversion
             cd /workspace
             bazel version
-            apt update && apt install -y libglib2.0-0
+            apt update && apt install -y libglib2.0-0 libgl1
             export EXECUTOR="base_executor_config"
             export TRAIN_SETTING="${{ matrix.model-name }}"
             export XLA_FLAGS="--xla_gpu_enable_latency_hiding_scheduler=True \
@@ -263,7 +289,12 @@ jobs:
                                 --xla_gpu_enable_command_buffer='' --xla_gpu_autotune_level=4"
             export PROJECT=byllama
             bash -i bazel_run_anynode.sh 2>&1 | tee logs.log
-            tail -n 25 logs.log > training_summary.txt'
+            # The DB parser only consumes "train step" lines. aiter can emit a lot
+            # of "[aiter WARNING] ... fwd_v3 ... bf16" messages, which would flood
+            # tail and hide the metric lines, so grep them first; fall back to the
+            # raw tail only if no step lines were produced (e.g. an early crash).
+            { grep -i "train step" logs.log || tail -n 25 logs.log; } \
+              | tail -n 25 > training_summary.txt'
       - name: Upload training summary
         uses: actions/upload-artifact@v4
         with:
@@ -286,9 +317,9 @@ jobs:
             model-name: "train_dense"
             rocm-version: "7.2.0"
             python-version: "3.12"
-          - jax-version: "0.9.2"
+          - jax-version: "0.10.2"
             model-name: "train_dense"
-            rocm-version: "7.2.0"
+            rocm-version: "7.14.0"
             python-version: "3.12"
     steps:
       - name: Checkout plugin repo


### PR DESCRIPTION
This PR updates the second parallel job to JAX 0.10.2 / ROCm 7.14.0 (TheRock). The 0.6.0 / ROCm 7.2.0 job is unchanged.

**Why 7.14**: earlier ROCm had a gfx950 GEMM autotuning issue in CI; resolved in TheRock 7.14.

Changes are as follows:
- Image `therock-7.14:7.14` from rocm-jax; JAX wheels from rocm/jax GitHub release (`JAX v0.10.2`).
- TE branch `veergopu/integrate-small-seq-mfma`; ref `matrix -> input -> default` keeps 0.6.0 locked.
- Resolve ROCm paths from `rocm-sdk` (no `/opt/rocm` on TheRock) so CMake links `ck_fused_attn`.
- Summary greps `train step` before `tail` so aiter `fwd_v3` warning messages can't starve the DB parser.
- Point `LD_LIBRARY_PATH` at `$(rocm-sdk path --root)/lib` so `libroctx64` resolves and the TE core `.so` loads.