### PR TITLE
Remove ci_build from build-base-docker.yml for Rock builds.

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -54,10 +54,13 @@ jobs:
         run: |
           NIGHTLY="https://rocm.nightlies.amd.com/whl-multi-arch/"
           GA="https://repo.amd.com/rocm/whl-multi-arch/"
+          GFX_ARCH="device-gfx942,device-gfx950"
           {
             echo 'entries<<JSON'
-            echo "[{\"therock-version\": \"\", \"therock-index-url\": \"$NIGHTLY\"},"
-            echo " {\"therock-version\": \"7.14\", \"therock-index-url\": \"$GA\"}]"
+            echo "[{\"therock-version\": \"\", \"therock-index-url\": \"$NIGHTLY\","
+            echo "  \"gfx-arch\": \"$GFX_ARCH\"},"
+            echo " {\"therock-version\": \"7.14\", \"therock-index-url\": \"$GA\","
+            echo "  \"gfx-arch\": \"$GFX_ARCH\"}]"
             echo 'JSON'
           } >> "$GITHUB_OUTPUT"
 
@@ -204,16 +207,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build TheRock base docker image
         run: |
-          python3 build/ci_build \
-            build_base_therock_dockers \
-            --filter="therock-ubu24" \
-            --therock-index-url="${{ matrix.therock.therock-index-url }}" \
-            ${{
-              matrix.therock.therock-version
-              && format('--therock-version="{0}"', matrix.therock.therock-version)
-              || ''
-            }} \
-            ${{ matrix.install-llvm && '--install-llvm --llvm-version 18' || '' }}
+          ver_slug="${{ matrix.therock.therock-version || 'latest' }}"
+          ver_slug="${ver_slug//+/.}"; ver_slug="${ver_slug// /}" # Match ci_build's sanitizing
+          if [ "${{ matrix.install-llvm }}" = "true" ]; then
+            image_tag="jax-dev-ubu24.therock-${ver_slug}"
+          else
+            image_tag="jax-base-ubu24.therock-${ver_slug}"
+          fi
+          docker build -f docker/Dockerfile.base-therock-ubu24 \
+            --build-arg=GFX_ARCH="${{ matrix.therock.gfx-arch }}" \
+            --build-arg=THEROCK_INDEX_URL="${{ matrix.therock.therock-index-url }}" \
+            --build-arg=THEROCK_VERSION="${{ matrix.therock.therock-version }}" \
+            --build-arg=INSTALL_LLVM=${{ matrix.install-llvm && '1' || '0' }} \
+            --build-arg=LLVM_VERSION=${{ matrix.install-llvm && '18' || 'none' }} \
+            -t "$image_tag" .
       - name: Authenticate to GitHub Container Registry
         if: github.event_name != 'pull_request'
         run: |
@@ -226,6 +233,7 @@ jobs:
           THEROCK_VERSION: ${{ matrix.therock.therock-version }}
         run: |
           ver_slug="${THEROCK_VERSION:-latest}"
+          ver_slug="${ver_slug//+/.}"; ver_slug="${ver_slug// /}" # Match ci_build's sanitizing
           if [ "$INSTALL_LLVM" = "true" ]; then
             image_tag="jax-dev-ubu24.therock-${ver_slug}"
           else
@@ -254,6 +262,7 @@ jobs:
           THEROCK_VERSION: ${{ matrix.therock.therock-version }}
         run: |
           ver_slug="${THEROCK_VERSION:-latest}"
+          ver_slug="${ver_slug//+/.}"; ver_slug="${ver_slug// /}" # Match ci_build's sanitizing
           if [ "$INSTALL_LLVM" = "true" ]; then
             image_tag="jax-dev-ubu24.therock-${ver_slug}"
           else
@@ -300,15 +309,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build TheRock manylinux docker image
         run: |
-          python3 build/ci_build \
-            build_manylinux_therock_dockers \
-            --therock-index-url="${{ matrix.therock.therock-index-url }}" \
-            ${{
-              matrix.therock.therock-version
-              && format('--therock-version="{0}"',
-                        matrix.therock.therock-version)
-              || ''
-            }}
+          ver_slug="${{ matrix.therock.therock-version || 'latest' }}"
+          ver_slug="${ver_slug//+/.}"; ver_slug="${ver_slug// /}" # Match ci_build's sanitizing
+          image_tag="jax-manylinux_2_28-therock-${ver_slug}"
+          docker build -f docker/manylinux/Dockerfile.jax-manylinux_2_28-therock \
+            --build-arg=THEROCK_INDEX_URL="${{ matrix.therock.therock-index-url }}" \
+            --build-arg=THEROCK_VERSION="${{ matrix.therock.therock-version }}" \
+            --build-arg=GFX_ARCH="${{ matrix.therock.gfx-arch }}" \
+            -t "$image_tag" .
       - name: Authenticate to GitHub Container Registry
         if: github.event_name != 'pull_request'
         run: |
@@ -321,6 +329,7 @@ jobs:
           THEROCK_VERSION: ${{ matrix.therock.therock-version }}
         run: |
           ver_slug="${THEROCK_VERSION:-latest}"
+          ver_slug="${ver_slug//+/.}"; ver_slug="${ver_slug// /}" # Match ci_build's sanitizing
           image_tag="jax-manylinux_2_28-therock-${ver_slug}"
           ghcr_base="ghcr.io/rocm/${image_tag}"
 
@@ -344,6 +353,7 @@ jobs:
           THEROCK_VERSION: ${{ matrix.therock.therock-version }}
         run: |
           ver_slug="${THEROCK_VERSION:-latest}"
+          ver_slug="${ver_slug//+/.}"; ver_slug="${ver_slug// /}" # Match ci_build's sanitizing
           image_tag="jax-manylinux_2_28-therock-${ver_slug}"
           ghcr_base="ghcr.io/rocm/${image_tag}"
 


### PR DESCRIPTION
## Motivation
The `ci_build` script is deprecated. This PR replaces `ci_build` references in TheRock image builds in `build-base-docker.yml` with plain docker build commands. This reduces reliance on a deprecated script and enables passing arguments directly to the dockerfiles which is important for specifying the architectures that the docker images are built for. The naming and sanitization for images have been maintained so for consumers of the image, this PR should be transparent.

Note that legacy ROCm has been left with `ci_build`. When legacy ROCm is deprecated, all references to `ci_build` can be removed entirely.

## Changes
All changes are contained to the `.github/workflows/build-base-docker.yml` file, specifically Rock based operations.