### PR TITLE
Add per-set granularity to base docker image dispatch

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -13,15 +13,17 @@ on:
         default: false
       image-set:
         description: >-
-          Which image set to build/repush on manual dispatch: 'legacy'
-          (rocm720), 'therock', or 'both'. Scheduled/push/PR build all.
+          Which image set to build/repush on manual dispatch: 'all',
+          'legacy' (apt ROCm 7.2.0), 'therock-pinned' (TheRock GA pin) or
+          'therock-latest' (TheRock nightly). Scheduled/push/PR build all.
         required: false
         type: choice
         options:
-          - therock
+          - all
           - legacy
-          - both
-        default: both
+          - therock-pinned
+          - therock-latest
+        default: all
   pull_request:
     paths:
       - 'build/ci_build'
@@ -42,36 +44,45 @@ jobs:
     # Single source of truth for the TheRock ROCm version + pip index, consumed
     # by both the base and manylinux TheRock jobs so they can't drift.
     # Pinned to TheRock 7.14 GA, served from the stable repo.amd.com index.
+    # The selected image set decides which TheRock entries end up in the matrix.
     if: >-
       github.event_name != 'workflow_dispatch' ||
-      inputs.image-set == 'therock' ||
-      inputs.image-set == 'both'
+      inputs.image-set != 'legacy'
     runs-on: ubuntu-latest
     outputs:
       entries: ${{ steps.set.outputs.entries }}
     steps:
       - id: set
+        env:
+          IMAGE_SET: ${{ inputs.image-set || 'all' }}
         run: |
           NIGHTLY="https://rocm.nightlies.amd.com/whl-multi-arch/"
           GA="https://repo.amd.com/rocm/whl-multi-arch/"
           GFX_ARCH="device-gfx942,device-gfx950"
+          latest="{\"therock-version\": \"\", \"therock-index-url\": \"$NIGHTLY\","
+          latest="$latest \"gfx-arch\": \"$GFX_ARCH\"}"
+          pinned="{\"therock-version\": \"7.14\", \"therock-index-url\": \"$GA\","
+          pinned="$pinned \"gfx-arch\": \"$GFX_ARCH\"}"
+          case "$IMAGE_SET" in
+            therock-latest) entries="[$latest]" ;;
+            therock-pinned) entries="[$pinned]" ;;
+            *) entries="[$latest, $pinned]" ;;
+          esac
+          echo "Image set '$IMAGE_SET' selects: $entries"
           {
             echo 'entries<<JSON'
-            echo "[{\"therock-version\": \"\", \"therock-index-url\": \"$NIGHTLY\","
-            echo "  \"gfx-arch\": \"$GFX_ARCH\"},"
-            echo " {\"therock-version\": \"7.14\", \"therock-index-url\": \"$GA\","
-            echo "  \"gfx-arch\": \"$GFX_ARCH\"}]"
+            echo "$entries"
             echo 'JSON'
           } >> "$GITHUB_OUTPUT"
 
   build-base-images:
     # Legacy apt-ROCm (rocm720) base/dev images, shared with jax-ml/jax upstream
     # (its pytest_rocm/bazel_rocm pin rocm-tag=rocm720). On manual dispatch only
-    # build when 'legacy' or 'both' is selected; scheduled/push/PR build all.
+    # build when 'legacy' or 'all' is selected; scheduled/push/PR build all.
     if: >-
       github.event_name != 'workflow_dispatch' ||
-      inputs.image-set == 'legacy' ||
-      inputs.image-set == 'both'
+      inputs.image-set == 'all' ||
+      inputs.image-set == 'legacy'
     name: >-
       ROCm ${{ matrix.rocm-version }},
       ${{ matrix.install-llvm && 'with' || 'without' }} LLVM
@@ -170,13 +181,12 @@ jobs:
           docker push "${ghcr_image_latest}"
 
   build-therock-base-images:
-    # TheRock base/dev images. On manual dispatch only build when 'therock' or
-    # 'both' is selected.
+    # TheRock base/dev images. On manual dispatch skipped for 'legacy'; which
+    # TheRock versions run is decided by the therock-config matrix.
     needs: therock-config
     if: >-
       github.event_name != 'workflow_dispatch' ||
-      inputs.image-set == 'therock' ||
-      inputs.image-set == 'both'
+      inputs.image-set != 'legacy'
     name: >-
       TheRock ${{ matrix.therock.therock-version || 'latest' }},
       ${{ matrix.install-llvm && 'with' || 'without' }} LLVM
@@ -275,12 +285,12 @@ jobs:
           docker push "${ghcr_base}:latest"
 
   build-therock-manylinux-images:
-    # TheRock manylinux builder image. Part of the 'therock' set.
+    # TheRock manylinux builder image. Follows the same image-set gating and
+    # therock-config matrix as the TheRock base images.
     needs: therock-config
     if: >-
       github.event_name != 'workflow_dispatch' ||
-      inputs.image-set == 'therock' ||
-      inputs.image-set == 'both'
+      inputs.image-set != 'legacy'
     name: "TheRock ${{ matrix.therock.therock-version || 'latest' }}, manylinux"
     runs-on: amd-do-linux.jax.cpu
     strategy:
@@ -365,8 +375,8 @@ jobs:
     # Legacy apt-ROCm 7.2.0 manylinux builder image. Part of the 'legacy' set.
     if: >-
       github.event_name != 'workflow_dispatch' ||
-      inputs.image-set == 'legacy' ||
-      inputs.image-set == 'both'
+      inputs.image-set == 'all' ||
+      inputs.image-set == 'legacy'
     name: "ROCm ${{ matrix.rocm-version }}, manylinux"
     runs-on: ${{ matrix.runner-label }}
     strategy:


### PR DESCRIPTION
## Summary

The `Build Base Docker Images` manual dispatch could only choose `legacy`, `therock`, or `both`. This splits it into four options so a run can target a single image family:

- `all` (default) - everything, same as the old `both`
- `legacy` - apt ROCm 7.2.0 images
- `therock-pinned` - TheRock GA pin (currently 7.14)
- `therock-latest` - TheRock nightly
