### PR TITLE
[jax] Remove unused LLVM build for JAX 0.10.2

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -33,23 +33,6 @@ RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python && \
     python -m ensurepip && python -m pip install auditwheel
 
-# Install LLVM 18 from source (manylinux has no apt):
-RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y wget && dnf clean all
-RUN mkdir /tmp/llvm-project && \
-    wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz \
-        | tar -xz -C /tmp/llvm-project --strip-components 1 && \
-    mkdir /tmp/llvm-project/build && \
-    cd /tmp/llvm-project/build && \
-    cmake -DLLVM_ENABLE_PROJECTS='clang;lld' \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ \
-          -DGCC_INSTALL_PREFIX=/opt/rh/gcc-toolset-14/root/usr \
-          ../llvm && \
-    make -j$(nproc) && \
-    make -j$(nproc) install && \
-    rm -rf /tmp/llvm-project
-
 # ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
 # libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in
 # /usr/lib64; the linker script lives in the non-standard gcc-toolset-14 path.


### PR DESCRIPTION
## Summary

Remove the LLVM 18 source build from the JAX 0.10.2 manylinux image.

JAX 0.10.2 builds release wheels with `rocm_clang_hermetic`, so the LLVM installation at `/usr/lib/llvm-18` is not used by the wheel build. Removing this block avoids spending several minutes building an unused LLVM toolchain in CI.

The existing `ld.lld` compatibility symlink is left unchanged.

## Validation

Built the updated `Dockerfile.jax-manylinux_2_28-therock` successfully using the standard `quay.io/pypa/manylinux_2_28_x86_64`

Verified in the resulting image that:

- `/usr/lib/llvm-18/bin/clang` is not present.
- `/tmp/llvm-project` is not present.
- `/usr/lib64/libstdc++.so` still points to `/usr/lib64/libstdc++.so.6`.

The validation completed successfully:

```text
PASS: LLVM 18 source install is absent
PASS: hermetic-linker libstdc++ symlink is preserved
```
This change is required for https://github.com/ROCm/TheRock/pull/7029.