### PR TITLE
[jax] Use prebuilt LLVM 18.1.8 for JAX 0.10.1

### DIFF
--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -34,22 +34,27 @@ RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python && \
     ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python3 && \
     python -m ensurepip && python -m pip install auditwheel
 
-# Install LLVM 18 from source (manylinux has no apt):
+# Install prebuilt LLVM 18.1.8 for clang_local.
 RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y wget && dnf clean all
-RUN mkdir /tmp/llvm-project && \
-    wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz \
-        | tar -xz -C /tmp/llvm-project --strip-components 1 && \
-    mkdir /tmp/llvm-project/build && \
-    cd /tmp/llvm-project/build && \
-    cmake -DLLVM_ENABLE_PROJECTS='clang;lld' \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ \
-          -DGCC_INSTALL_PREFIX=/opt/rh/gcc-toolset-14/root/usr \
-          ../llvm && \
-    make -j$(nproc) && \
-    make -j$(nproc) install && \
-    rm -rf /tmp/llvm-project
+    dnf install -y wget xz ncurses-compat-libs && \
+    dnf clean all
+
+RUN wget -q \
+    "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz" \
+    -O /tmp/llvm.tar.xz && \
+    echo "54ec30358afcc9fb8aa74307db3046f5187f9fb89fb37064cdde906e062ebf36 /tmp/llvm.tar.xz" \
+        | sha256sum -c - && \
+    mkdir -p /usr/lib/llvm-18 && \
+    tar -xJf /tmp/llvm.tar.xz \
+        -C /usr/lib/llvm-18 \
+        --strip-components=1 && \
+    rm /tmp/llvm.tar.xz && \
+    printf '%s\n' \
+        '--gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr' \
+        > /usr/lib/llvm-18/bin/clang.cfg && \
+    cp /usr/lib/llvm-18/bin/clang.cfg \
+        /usr/lib/llvm-18/bin/clang++.cfg && \
+    /usr/lib/llvm-18/bin/clang --version | grep -Fq "Configuration file: /usr/lib/llvm-18/bin/clang.cfg"
 
 # ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
 # libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in


### PR DESCRIPTION
## Summary

Replace the LLVM 18.1.8 source build in the JAX 0.10.1 manylinux
Docker image with the official prebuilt LLVM 18.1.8 binary.

JAX 0.10.1 uses `clang_local` and expects Clang at:

`/usr/lib/llvm-18/bin/clang`

The prebuilt archive is therefore extracted to the same location, preserving
the existing compiler path while avoiding the full LLVM source build.

The GCC toolchain configuration previously supplied through
`GCC_INSTALL_PREFIX` is preserved with `clang.cfg` / `clang++.cfg`:

`--gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr`

The LLVM archive is pinned by SHA256.

## Validation

Validated by building the updated `quay.io/pypa/manylinux_2_28_x86_64` based
Docker image.

Observed:

```text
/tmp/llvm.tar.xz: OK
clang version 18.1.8
InstalledDir: /usr/lib/llvm-18/bin
Configuration file: /usr/lib/llvm-18/bin/clang.cfg
```

Also verified:

* `clang.cfg` and `clang++.cfg` use the GCC toolchain at
  `/opt/rh/gcc-toolset-14/root/usr`
* `clang++` successfully compiles, links, and runs a C++ test program

This change is required for https://github.com/ROCm/TheRock/pull/7029.
