### PR TITLE
Add Python 3.15 to the ubu24 base images

### DIFF
--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -30,8 +30,19 @@ RUN --mount=type=cache,target=/var/cache/apt \
         python3.13-nogil \
         python3.14 python3.14-dev python3.14-venv \
         python3.14-nogil \
+        python3.15 python3.15-dev python3.15-venv \
+        python3.15-nogil \
         python3-pip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Ubuntu's system pip (24.0) crashes on Python 3.15 (it cannot instantiate
+# importlib.metadata's WheelDistribution). Install the pip bundled with 3.15's
+# ensurepip into /usr/local/lib/python3.15/dist-packages, which precedes
+# /usr/lib/python3/dist-packages on sys.path. Only 3.15 is affected; the other
+# interpreters keep using the system pip.
+RUN PIP_WHEEL=$(ls /usr/lib/python3.15/ensurepip/_bundled/pip-*.whl) && \
+    python3.15 "$PIP_WHEEL/pip" install --no-index --break-system-packages \
+        --ignore-installed "$PIP_WHEEL"
 
 # Set default Python to 3.12:
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 100 && \
@@ -142,6 +153,6 @@ ENV ROCPROFILER_QUEUE_INTERPOSITION=0 \
 LABEL com.amdgpu.therock_index_url="$THEROCK_INDEX_URL" \
       com.amdgpu.therock_version="$THEROCK_VERSION" \
       com.amdgpu.gfx_arch="$GFX_ARCH" \
-      com.amdgpu.python_versions="3.11,3.12,3.13,3.13-nogil,3.14,3.14-nogil" \
+      com.amdgpu.python_versions="3.11,3.12,3.13,3.13-nogil,3.14,3.14-nogil,3.15,3.15-nogil" \
       com.amdgpu.install_llvm="$INSTALL_LLVM" \
       com.amdgpu.llvm_version="$LLVM_VERSION"


### PR DESCRIPTION
Adds Python 3.15 to both ubu24 base images so they ship a usable 3.15 alongside 3.11-3.14. deadsnakes currently has 3.15.0rc1 for noble.

Installs `python3.15`, `python3.15-dev`, `python3.15-venv` and `python3.15-nogil` following the existing 3.14 pattern, and updates the `com.amdgpu.python_versions` label.

The images share one system pip (24.0) across every interpreter via `/usr/lib/python3/dist-packages`. It reports a version on 3.15 but fails any actual install with `TypeError: Can't instantiate abstract class WheelDistribution`. So this also bootstraps the pip bundled in 3.15's own ensurepip (26.2) into `/usr/local/lib/python3.15/dist-packages`, which precedes the system path. `ensurepip --upgrade` does not work here: it tries to uninstall the dpkg-owned pip and fails on `uninstall-no-record-file`. 3.11-3.14 keep pip 24.0 unchanged.

Test: built the Python layers of both Dockerfiles locally. All eight interpreters present, 3.15.0rc1 resolves and installs packages with pip 26.2, `python3.15t` free-threaded present, `python3`/`python` still 3.12, and 3.11-3.14 unchanged.

`Dockerfile.jax-ubu24` is deliberately left alone: `jaxlib==0.10.0`, `scipy` and `matplotlib` have no cp315 wheels yet, so adding 3.15 to its install loop would break the build. The `python-versions` defaults in the workflows and `build/ci_build` stay as they are for the same reason, since that list drives cp315 plugin wheel builds. Both are a small follow-up once cp315 wheels land.
