### PR TITLE
Replace rocm-smi with amd-smi in CI and Docker build

### DIFF
--- a/.github/workflows/build_hermetic_ubu24_docker.yml
+++ b/.github/workflows/build_hermetic_ubu24_docker.yml
@@ -57,7 +57,7 @@ jobs:
           whoami
           printenv
           df -h
-          rocm-smi -a || true
+          amd-smi list || true
           rocminfo | grep gfx || true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -99,7 +99,6 @@ RUN ROCM_VERS=${ROCM_VERSION} && \
         rccl-dbgsym \
         rocfft-dbgsym \
         rocm-core-dbgsym \
-        rocm-smi-lib-dbgsym \
         rocprofiler-sdk-dbgsym \
         rocsparse-dbgsym && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Replace `rocm-smi -a` with `amd-smi list` in the hermetic docker workflow.
- Remove `rocm-smi-lib-dbgsym` from `Dockerfile.rocm` (deprecated per ROCm/TheRock#6852).

## Test plan
- [x] `amd-smi list` exits 0 on ROCm 7.14
- [ ] Docker build workflow passes