### PR TITLE
Update docker build runner labels to amd-do-linux.jax.cpu

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -57,7 +57,7 @@ jobs:
         install-llvm: [true, false]
         include:
           - rocm-version: "7.2.0"
-            runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
+            runner-label: "amd-do-linux.jax.cpu"
     steps:
       - name: Clean up old runs
         run: |
@@ -160,7 +160,7 @@ jobs:
         install-llvm: [true, false]
         therock-version: ["", "7.13.0"]
         include:
-          - runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
+          - runner-label: "amd-do-linux.jax.cpu"
           - therock-version: ""
             therock-index-url: "https://rocm.nightlies.amd.com/whl-multi-arch/"
           - therock-version: "7.13.0"
@@ -252,7 +252,7 @@ jobs:
       inputs.image-set == 'therock' ||
       inputs.image-set == 'both'
     name: "TheRock ${{ matrix.therock-version || 'latest' }}, manylinux"
-    runs-on: amd-do-linux.rocm-jax.gpu.gfx950.1
+    runs-on: amd-do-linux.jax.cpu
     strategy:
       fail-fast: false
       matrix:
@@ -349,7 +349,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
+            runner-label: "amd-do-linux.jax.cpu"
     steps:
       - name: Clean up old runs
         run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,7 +34,7 @@ on:
           path component of the S3 LATEST pointer.
         required: false
         type: string
-        default: 'test/org-gated-ci'
+        default: 'rocm-jaxlib-v0.10.1'
       rocm-release-version:
         description: |
           Full ROCm release version used to resolve the S3 LATEST pointer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
-      runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
+      runner-label: '["amd-do-linux.jax.cpu"]'
   run-python-unit-tests:
     name: run-python-unit-tests (deprecated)
     needs: call-build-docker

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
+            runner-label: '["amd-do-linux.jax.cpu"]'
     uses: ./.github/workflows/build-wheels.yml
     with:
       python-versions: "3.11,3.12,3.13,3.14"
@@ -44,7 +44,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
+            runner-label: '["amd-do-linux.jax.cpu"]'
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}


### PR DESCRIPTION
## Motivation

CI on `rocm-jaxlib-v0.10.1` is stuck for two independent reasons, both from the branch drifting after it was cut. First, the `amd-do-linux.rocm-jax.gpu.gfx950.1` runner label it is pinned to no longer exists, so every docker build job queues forever and PR checks never complete. Second, `build-docker.yml` still defaults `wheels-ref` to `test/org-gated-ci`, the development branch it was written against, so the wheel download resolves an S3 LATEST pointer that now returns 403.

## Technical Details

- Replaces all 7 occurrences of `amd-do-linux.rocm-jax.gpu.gfx950.1` with `amd-do-linux.jax.cpu`, in `build-base-docker.yml` (4), `ci.yml` (1), and `nightly.yml` (2). Label-only; no job logic or workflow structure touched. This applies the two moves the branch missed: #472 dropped the `rocm-` prefix from the org segment, then #486 moved docker image builds off the GPU pool onto CPU runners.
- Defaults `wheels-ref` to `rocm-jaxlib-v0.10.1` so the docker build pulls the wheels validated for this release rather than a development branch. Setting the default rather than passing the input from each caller covers `ci.yml`, `nightly.yml`, and `workflow_dispatch` in one line.
- No GPU is needed for the relabelled jobs: they only run `ci_build`'s `build_*_dockers` subcommands plus `docker push`. The `--device=/dev/kfd` / `--device=/dev/dri` flags live only in `ci_build`'s `test()`, which no workflow here calls, and the `rocm-smi` / `rocminfo` probe steps are already `|| true`-guarded.
- `llama-perf.yml` (`linux-jax-mi355-*`), `mysqldb`, and all `ubuntu-latest` jobs are untouched, matching `rocm-jax-infra`.

## Test Plan

This PR self-validates: it edits the three workflows that gate it, so `ci.yml` (via `branches: [rocm-jaxlib-v*]`) and `build-base-docker.yml` / `nightly.yml` (via their `paths:` filters) all run against the change.

## Test Result

The label change already went green on this branch: 9/9 base docker images built, with the `Build Base Docker Images` run concluding success. The only remaining failures were the two `build-docker` jobs hitting the 403, which the `wheels-ref` change addresses.

The new pointer resolves and carries the right artifacts, verified directly:

```
.../rocm-wheels/ROCm/jax/test/org-gated-ci/7.2.0/LATEST    -> 403 AccessDenied
.../rocm-wheels/ROCm/jax/rocm-jaxlib-v0.10.1/7.2.0/LATEST  -> 200
   s3://jax-ci-amd/rocm-wheels/ROCm/jax/rocm-jaxlib-v0.10.1/7.2.0/release-validation/69/1
     jax_rocm7_pjrt-0.10.1.post2-py3-none-manylinux_2_27_x86_64.whl
     jax_rocm7_plugin-0.10.1.post2-cp{311,312,313,314}-...whl
```

Namespace and Python versions match what the workflow expects (`jax_rocm7_*`, `python-versions: '3.11,3.12,3.13,3.14'`), and the wheel version matches the branch. `yamllint -c .yamllint.yml --strict` reports 0 findings.
