### PR TITLE
Update docker build runner labels to amd-do-linux.jax.cpu

### DIFF
--- a/.github/workflows/build-base-docker.yml
+++ b/.github/workflows/build-base-docker.yml
@@ -57,7 +57,7 @@ jobs:
         install-llvm: [true, false]
         include:
           - rocm-version: "7.2.0"
-            runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
+            runner-label: "amd-do-linux.jax.cpu"
     steps:
       - name: Clean up old runs
         run: |
@@ -160,7 +160,7 @@ jobs:
         install-llvm: [true, false]
         therock-version: ["", "7.13.0"]
         include:
-          - runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
+          - runner-label: "amd-do-linux.jax.cpu"
           - therock-version: ""
             therock-index-url: "https://rocm.nightlies.amd.com/whl-multi-arch/"
           - therock-version: "7.13.0"
@@ -252,7 +252,7 @@ jobs:
       inputs.image-set == 'therock' ||
       inputs.image-set == 'both'
     name: "TheRock ${{ matrix.therock-version || 'latest' }}, manylinux"
-    runs-on: amd-do-linux.rocm-jax.gpu.gfx950.1
+    runs-on: amd-do-linux.jax.cpu
     strategy:
       fail-fast: false
       matrix:
@@ -349,7 +349,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: "amd-do-linux.rocm-jax.gpu.gfx950.1"
+            runner-label: "amd-do-linux.jax.cpu"
     steps:
       - name: Clean up old runs
         run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,7 +34,7 @@ on:
           path component of the S3 LATEST pointer.
         required: false
         type: string
-        default: 'test/org-gated-ci'
+        default: 'rocm-jaxlib-v0.10.0'
       rocm-release-version:
         description: |
           Full ROCm release version used to resolve the S3 LATEST pointer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}
-      runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
+      runner-label: '["amd-do-linux.jax.cpu"]'
   run-python-unit-tests:
     name: run-python-unit-tests (deprecated)
     needs: call-build-docker

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
+            runner-label: '["amd-do-linux.jax.cpu"]'
     uses: ./.github/workflows/build-wheels.yml
     with:
       python-versions: "3.11,3.12,3.13,3.14"
@@ -44,7 +44,7 @@ jobs:
         rocm-version: ["7.2.0"]
         include:
           - rocm-version: "7.2.0"
-            runner-label: '["amd-do-linux.rocm-jax.gpu.gfx950.1"]'
+            runner-label: '["amd-do-linux.jax.cpu"]'
     uses: ./.github/workflows/build-docker.yml
     with:
       rocm-version: ${{ matrix.rocm-version }}

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-rocm
@@ -39,7 +39,8 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 
 # The manylinux base image provides python3 but not unversioned 'python'.
 # CI scripts currently require this so we symlink Python to Python3.
-RUN ln -s /usr/bin/python3.11 /usr/local/bin/python
+RUN ln -s /usr/bin/python3.12 /usr/local/bin/python && \
+    ln -s /usr/bin/python3.12 /usr/local/bin/python3
 
 # ld.lld (hermetic linker) resolves -lstdc++ by looking for the unversioned
 # libstdc++.so in the sysroot. AlmaLinux 8 only ships libstdc++.so.6 in

--- a/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
+++ b/docker/manylinux/Dockerfile.jax-manylinux_2_28-therock
@@ -31,6 +31,7 @@ RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     rocm-sdk init
 
 RUN ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python && \
+    ln -s /opt/python/cp312-cp312/bin/python3 /usr/local/bin/python3 && \
     python -m ensurepip && python -m pip install auditwheel
 
 # Install LLVM 18 from source (manylinux has no apt):


### PR DESCRIPTION
## Motivation

Same fixes as #512, applied to `rocm-jaxlib-v0.10.0`, plus one backport this branch needs to build at all. Three independent problems, all from the branch drifting after it was cut:

1. The `amd-do-linux.rocm-jax.gpu.gfx950.1` runner label no longer exists, so every docker build job queues forever and PR checks never complete.
2. `build-docker.yml` still defaults `wheels-ref` to `test/org-gated-ci`, the development branch it was written against, so the wheel download resolves an S3 LATEST pointer that now returns 403.
3. The manylinux image fails to build with `/bin/sh: python: command not found`. `Dockerfile.jax-manylinux_2_28-rocm` symlinks `/usr/bin/python3.11`, which the floating `quay.io/pypa/manylinux_2_28_x86_64` base no longer ships (its system Python is 3.12). `ln -s` does not validate its target, so the link is created silently and only fails when something executes it nine lines later. #484 fixed this on `rocm-jaxlib-v0.10.1` and was never backported here.

## Technical Details

- `be402eda0` — replaces all 7 occurrences of `amd-do-linux.rocm-jax.gpu.gfx950.1` with `amd-do-linux.jax.cpu`, in `build-base-docker.yml` (4), `ci.yml` (1), and `nightly.yml` (2). Label-only; no job logic or workflow structure touched. Applies the two moves the branch missed: #472 dropped the `rocm-` prefix, then #486 moved docker image builds onto CPU runners.
- `de15e6db1` — clean cherry-pick of #484 (`2746139b9`), pointing the manylinux symlinks at `python3.12` and adding the `/usr/local/bin/python3` override. Both manylinux Dockerfiles are now byte-identical to `rocm-jaxlib-v0.10.1`.
- `ff7313dee` — defaults `wheels-ref` to `rocm-jaxlib-v0.10.0` so the docker build pulls the wheels validated for this release. Setting the default rather than passing the input from each caller covers `ci.yml`, `nightly.yml`, and `workflow_dispatch` in one line.
- No GPU is needed for the relabelled jobs: they only run `ci_build`'s `build_*_dockers` subcommands plus `docker push`. The `--device=/dev/kfd` / `--device=/dev/dri` flags live only in `ci_build`'s `test()`, which no workflow here calls, and the `rocm-smi` / `rocminfo` probe steps are already `|| true`-guarded.
- `llama-perf.yml` (`linux-jax-mi355-*`), `mysqldb`, and all `ubuntu-latest` jobs are untouched, matching `rocm-jax-infra`.

## Test Plan

This PR self-validates: it edits the three workflows that gate it, so `ci.yml` (via `branches: [rocm-jaxlib-v*]`) and `build-base-docker.yml` / `nightly.yml` (via their `paths:` filters) all run against the change, and the base-docker matrix exercises the manylinux Dockerfile directly.

## Test Result

The label change already went green: jobs schedule and 8/9 base docker images built, the one failure being the `python3.11` symlink that the #484 backport fixes. The same job passes on #512, which already carries that commit.

The new wheel pointer resolves and carries the right artifacts, verified directly:

```
.../rocm-wheels/ROCm/jax/test/org-gated-ci/7.2.0/LATEST    -> 403 AccessDenied
.../rocm-wheels/ROCm/jax/rocm-jaxlib-v0.10.0/7.2.0/LATEST  -> 200
   s3://jax-ci-amd/rocm-wheels/ROCm/jax/rocm-jaxlib-v0.10.0/7.2.0/release-validation/70/1
     jax_rocm7_pjrt-0.10.0.post2-py3-none-manylinux_2_27_x86_64.whl
     jax_rocm7_plugin-0.10.0.post2-cp{311,312,313,314}-...whl
```

Namespace and Python versions match what the workflow expects (`jax_rocm7_*`, `python-versions: '3.11,3.12,3.13,3.14'`), and the wheel version matches the branch. `yamllint -c .yamllint.yml --strict` reports 0 findings.
