### PR TITLE
Silence the rocprofiler-sdk finalize warning in the TheRock base image

### DIFF
--- a/docker/Dockerfile.base-therock-ubu24
+++ b/docker/Dockerfile.base-therock-ubu24
@@ -138,7 +138,10 @@ RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     rocm-sdk init
 
 # ROCm/HIP runtime tuning:
+# ROCPROFILER_LOG_LEVEL is a workaround until the fix from the SDK team lands
+# in ROCm. TODO:magaonka-amd remove this once the fix is landed.
 ENV ROCPROFILER_QUEUE_INTERPOSITION=0 \
+    ROCPROFILER_LOG_LEVEL=error \
     DEBUG_HIP_DYNAMIC_QUEUES=0
 
 # Export NO ROCm env: this image is intentionally /opt/rocm-less. ROCm resolves


### PR DESCRIPTION
## Summary

Sets `ROCPROFILER_LOG_LEVEL=error` in the TheRock ubu24 base image. rocprofiler-sdk
defaults to a WARNING minimum log level and emits a warning from its finalize path on
every process exit, which fails upstream JAX tests asserting a subprocess produced no
stderr output:

```
FAILED tests/logging_test.py::LoggingTest::test_subprocess_toggling_logging_level - AssertionError:
- W0830 14:24:47.935962   75372 registration.cpp:946] invoking tool finalize for XLA-with-rocprofiler-sdk :: ...
```

Workaround to keep upstream CI green until the SDK-side fix lands in ROCm. The env var
carries a TODO for removal at that point.
